### PR TITLE
Get Patches

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -1,5 +1,6 @@
 name: CI
 on:
+- push
 - pull_request
 
 jobs:

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -1,6 +1,5 @@
 name: CI
 on:
-- push
 - pull_request
 
 jobs:

--- a/.github/workflows/galaxy-release.yml
+++ b/.github/workflows/galaxy-release.yml
@@ -1,0 +1,31 @@
+---
+name: galaxy-release
+on: 
+  release:
+    types:
+      - published
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      ANSIBLE_FORCE_COLOR: 1
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: Install ansible-base
+        run: pip install ansible
+      
+      - name: Publish to galaxy
+        run: ansible-playbook release.yml
+          -e collection_namespace=${{ github.repository_owner }}
+          -e github_tag=${{ github.ref }}
+          -e api_key=${{ secrets.ANSIBLE_GALAXY_APIKEY }}
+          -e collection_repo=https://github.com/${{ github.repository }}
+          --skip-tags=install,cleanup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Insights Collection Changes
+
+## [unreleased]
+### Added
+ - get_patching option added to insights inventory plugin fetches patching data from Insights patching service.
+ - vars_prefix option added to insights inventory plugin allows for customization of host var variable prefix.
+
+### Fixed
+ - updated inventory endpoint url to incldue all staleness states.
+
+## [0.0.1]
+### Added
+ - insights_client role for installing and registering a system to insights. Note: if migrating from previous version of role, name has changed from `insights-client` to `insights_client`.
+ - insights inventory plugin for fetching dynamic inventory from Insights inventory service.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Red Hat Insights Collection
 ## Included Content:
 
   - **Inventory source**:
-    - insights
+    - [insights](docs/inventory.md)
   - **Modules**:
     - insights_config
     - insights_register

--- a/docs/create_docs.yml
+++ b/docs/create_docs.yml
@@ -8,5 +8,5 @@
         examples: "{{ lookup('file', '../plugins/inventory/insights.py') | regex_search(\"(?<=EXAMPLES\\s=\\s''')((.|\\n)*?)(?=''')\") }}"
 
     - template:
-        src: ./inventory.md.j2
+        src: ./templates/inventory.md.j2
         dest: ./inventory.md

--- a/docs/create_docs.yml
+++ b/docs/create_docs.yml
@@ -1,0 +1,12 @@
+---
+- hosts: localhost
+  gather_facts: no
+
+  tasks:
+    - set_fact:
+        docs: "{{ lookup('file', '../plugins/inventory/insights.py') | regex_search(\"(?<=DOCUMENTATION\\s=\\s''')((.|\\n)*?)(?=''')\") | from_yaml}}"
+        examples: "{{ lookup('file', '../plugins/inventory/insights.py') | regex_search(\"(?<=EXAMPLES\\s=\\s''')((.|\\n)*?)(?=''')\") }}"
+
+    - template:
+        src: ./inventory.md.j2
+        dest: ./inventory.md

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -1,0 +1,85 @@
+insights - insights inventory source
+====================================
+- [Synopsis](Synopsis)
+- [Requirements](Requirements)
+- [Parameters](Parameters)
+- [Examples](Examples)
+
+## Synopsis
+- Get inventory hosts from the cloud.redhat.com inventory service.
+- Uses a YAML configuration file that ends with ``insights.(yml|yaml)``.
+
+## Requirements
+- requests >= 1.1
+
+## Parameters
+
+<table>
+<tr>
+<th> Parameter </th>
+<th> Choices/Defaults </th>
+<th> Configuration </th>
+<th> Comments </th>
+</tr>
+<tr>
+<td><b>get_patches</b></br>
+</td>
+<td><b>Default:</b><br> 
+False</td>
+<td></td>
+<td> Fetch patching information for each system.</td>
+</tr>
+<tr>
+<td><b>password</b></br>
+<p style="color:red;font-size:75%">required</p></td>
+<td></td>
+<td><b>env:</b><br>
+-   name: INSIGHTS_PASSWORD
+</td>
+<td> Red Hat password</td>
+</tr>
+<tr>
+<td><b>user</b></br>
+<p style="color:red;font-size:75%">required</p></td>
+<td></td>
+<td><b>env:</b><br>
+-   name: INSIGHTS_USER
+</td>
+<td> Red Hat username</td>
+</tr>
+<tr>
+<td><b>vars_prefix</b></br>
+</td>
+<td><b>Default:</b><br> 
+insights_</td>
+<td></td>
+<td> prefix to apply to host variables</td>
+</tr>
+<tr>
+<td><b>plugin</b></br>
+<p style="color:red;font-size:75%">required</p></td>
+<td><b>Choices:</b><br>
+- redhat.insights.insights
+</td>
+<td></td>
+<td> the name of this plugin, it should always be set to 'redhat.insights.insights' for this plugin to recognize it as it's own.</td>
+</tr>
+</table>
+
+## Examples
+```
+
+# basic example using environment vars for auth
+plugin: redhat.insights.insights
+
+# create groups for patching
+plugin: redhat.insights.insights
+get_patches: yes
+groups:
+  patching: insights_patching.enabled
+  stale: insights_patching.stale
+  bug_patch: insights_patching.rhba_count > 0
+  security_patch: insights_patching.rhsa_count > 0
+  enhancement_patch: insights_patching.rhea_count > 0
+
+```

--- a/docs/templates/inventory.md.j2
+++ b/docs/templates/inventory.md.j2
@@ -1,0 +1,38 @@
+{{ docs.name }} - {{ docs.short_description }}
+====================================
+- [Synopsis](Synopsis)
+- [Requirements](Requirements)
+- [Parameters](Parameters)
+- [Examples](Examples)
+
+## Synopsis
+{{ docs.description | to_nice_yaml}}
+## Requirements
+{{ docs.requirements | default('') | to_nice_yaml }}
+## Parameters
+
+<table>
+<tr>
+<th> Parameter </th>
+<th> Choices/Defaults </th>
+<th> Configuration </th>
+<th> Comments </th>
+</tr>
+{% for option in docs.options %}
+<tr>
+<td><b>{{ option }}</b></br>
+{% if docs.options[option]['required'] is defined and docs.options[option]['required'] %}<p style="color:red;font-size:75%">required</p>{% endif %}</td>
+<td>{% if docs.options[option]['choices'] is defined %}<b>Choices:</b><br>
+{{ docs.options[option]['choices'] | to_nice_yaml }}{% endif %}{% if docs.options[option]['default'] is defined %}<b>Default:</b><br> 
+{{ docs.options[option]['default'] }}{% endif %}</td>
+<td>{% if docs.options[option]['env'] is defined %}<b>env:</b><br>
+{{ docs.options[option]['env'] | to_nice_yaml }}{% endif %}</td>
+<td> {{ docs.options[option]['description'] }}</td>
+</tr>
+{% endfor %}
+</table>
+
+## Examples
+```
+{{ examples }}
+```

--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -110,7 +110,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         vars_prefix = self.get_option('vars_prefix')
         results = []
 
-        self.headers = { "Accept": "application/json" }
+        self.headers = {"Accept": "application/json"}
         self.auth = requests.auth.HTTPBasicAuth(self.get_option('user'), self.get_option('password'))
         self.session = requests.Session()
 
@@ -157,13 +157,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             if get_patches:
                 if host_name in patching.keys():
                         self.inventory.set_variable(host_name, vars_prefix + 'patching',
-                                                     patching[host['display_name']])
+                                                    patching[host['display_name']])
                 else:
                     self.inventory.set_variable(host_name, vars_prefix + 'patching', {'enabled': False})
 
             self._set_composite_vars(
                 self.get_option('compose'),
-                self.inventory.get_host(host_name).get_vars(), 
+                self.inventory.get_host(host_name).get_vars(),
                 host_name, strict)
 
             self._add_host_to_composed_groups(self.get_option('groups'),

--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -156,8 +156,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
             if get_patches:
                 if host_name in patching.keys():
-                        self.inventory.set_variable(host_name, vars_prefix + 'patching',
-                                                    patching[host['display_name']])
+                    self.inventory.set_variable(host_name, vars_prefix + 'patching',
+                                                patching[host['display_name']])
                 else:
                     self.inventory.set_variable(host_name, vars_prefix + 'patching', {'enabled': False})
 

--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -135,8 +135,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                     if attribute != 'display_name':
                         patching[display_name][attribute] = system['attributes'][attribute]
 
-            print(patching)
-
         for host in results:
             host_name = self.inventory.add_host(host['display_name'])
             for item in host.keys():

--- a/release.yml
+++ b/release.yml
@@ -6,7 +6,7 @@
   vars:
     collection_namespace: redhatinsights
     collection_name: insights
-    collection_version: "{{ version }}"
+    collection_version: "{{ github_tag.split('/')[-1] | regex_search('(\\d.\\d.\\d.*)') }}"
     collection_repo: https://github.com/redhatinsights/ansible-collections-insights
     api_key: undef
 
@@ -35,22 +35,27 @@
         cmd: ansible-galaxy collection build
         chdir: "{{ playbook_dir }}"
         creates: "{{ playbook_dir }}/{{ collection_namespace }}-{{ collection_name }}-{{ collection_version }}.tar.gz"
+      tags: build
 
     - name: install collection
       command:
         cmd: "ansible-galaxy collection install {{ collection_namespace }}-{{ collection_name }}-{{ collection_version }}.tar.gz -p ~/.ansible/collections/"
         chdir: "{{ playbook_dir }}"
+      tags: install
 
     - name: publish collection
       command:
         cmd: "ansible-galaxy collection publish --api-key={{ api_key }} {{ collection_namespace }}-{{ collection_name }}-{{ collection_version }}.tar.gz"
         chdir: "{{ playbook_dir }}"
+      tags: publish
 
     - name: git cleanup
       command:
         cmd: git reset --hard
+      tags: cleanup
 
     - name: remove galaxy.yml
       file:
         path: "{{ playbook_dir }}/galaxy.yml"
         state: absent
+      tags: cleanup

--- a/tests/inventory/insights.yml
+++ b/tests/inventory/insights.yml
@@ -1,0 +1,9 @@
+---
+plugin: redhat.insights.insights
+get_patches: yes
+groups:
+  patching: insights_patching.enabled
+  stale: insights_patching.stale
+  bug_patch: insights_patching.rhba_count > 0
+  security_patch: insights_patching.rhsa_count > 0
+  enhancement_patch: insights_patching.rhea_count > 0


### PR DESCRIPTION
This update to the insights inventory plugin adds an option to pull patching information from insights service to create additional host vars. The additional variables added are:
```
insights_patching:
  enabled: true|false
  last_evaluation: time/date
  last_upload: time/date
  rhba_count: bug advisory count
  rhea_count: enhancement advisory count
  rhsa_count: security advisory count
  stale: true|false
```
This data can be used to create groups as shown in `tests/inventory/insights.yml`. The `groups` sections will compose groups based on host var conditions. The following example will create a group for each type of advisory
```
groups:
  bug_patch: insights_patching.rhba_count > 0
  security_patch: insights_patching.rhsa_count > 0
  enhancement_patch: insights_patching.rhea_count > 0  
```

Additional changes: 
- add vars_prefix option to allow the user to customize the prefix of host_vars gathered from insights
- update inventory endpoint url to include all states of staleness. Default endpoint url excludes stale_warning state
- added docs for inventory plugin
