### PR TITLE
Add Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Red Hat Insights Collection
   - **Inventory source**:
     - [insights](docs/inventory.md)
   - **Modules**:
-    - insights_config
-    - insights_register
+    - [insights_config](docs/insights_config.md)
+    - [insights_register](docs/insights_register.md)
   - **Roles**:
-    - [insights_client](roles/insights-client/README.md)
+    - [insights_client](roles/insights_client/README.md)

--- a/docs/create_docs.yml
+++ b/docs/create_docs.yml
@@ -8,5 +8,21 @@
         examples: "{{ lookup('file', '../plugins/inventory/insights.py') | regex_search(\"(?<=EXAMPLES\\s=\\s''')((.|\\n)*?)(?=''')\") }}"
 
     - template:
-        src: ./templates/inventory.md.j2
+        src: ./templates/docs.md.j2
         dest: ./inventory.md
+
+    - set_fact:
+        docs: "{{ lookup('file', '../plugins/modules/insights_register.py') | regex_search(\"(?<=DOCUMENTATION\\s=\\s''')((.|\\n)*?)(?=''')\") | from_yaml}}"
+        examples: "{{ lookup('file', '../plugins/modules/insights_register.py') | regex_search(\"(?<=EXAMPLES\\s=\\s''')((.|\\n)*?)(?=''')\") }}"
+
+    - template:
+        src: ./templates/docs.md.j2
+        dest: ./insights_register.md
+
+    - set_fact:
+        docs: "{{ lookup('file', '../plugins/modules/insights_config.py') | regex_search(\"(?<=DOCUMENTATION\\s=\\s''')((.|\\n)*?)(?=''')\") | from_yaml}}"
+        examples: "{{ lookup('file', '../plugins/modules/insights_config.py') | regex_search(\"(?<=EXAMPLES\\s=\\s''')((.|\\n)*?)(?=''')\") }}"
+
+    - template:
+        src: ./templates/docs.md.j2
+        dest: ./insights_config.md

--- a/docs/insights_config.md
+++ b/docs/insights_config.md
@@ -1,0 +1,107 @@
+insights_config - This module handles initial configuration of the insights client on install
+====================================
+- [Synopsis](Synopsis)
+- [Requirements](Requirements)
+- [Parameters](Parameters)
+- [Examples](Examples)
+
+## Synopsis
+'Supply values for various configuration options that you would like to use. On install
+    this module will add those values to the insights-client.conf file prior to registering.
+
+    '
+
+## Requirements
+''
+
+## Parameters
+
+<table>
+<tr>
+<th> Parameter </th>
+<th> Choices/Defaults </th>
+<th> Configuration </th>
+<th> Comments </th>
+</tr>
+<tr>
+<td><b>username</b></br>
+</td>
+<td></td>
+<td></td>
+<td> Insights basic auth username. If defined this will change, set, or remove the username in the insights configuration. To remove a username set this value to an empty string.
+</td>
+</tr>
+<tr>
+<td><b>insights_name</b></br>
+</td>
+<td></td>
+<td></td>
+<td> For now, this is just 'insights-client', but it could change in the future so having it as a variable is just preparing for that.
+</td>
+</tr>
+<tr>
+<td><b>display_name</b></br>
+</td>
+<td></td>
+<td></td>
+<td> Custom display name to appear in the Insights web UI. Only used on machine registration. Blank by default.
+</td>
+</tr>
+<tr>
+<td><b>auto_config</b></br>
+</td>
+<td></td>
+<td></td>
+<td> [u'Attempt to auto-configure the network connection with Satellite or RHSM. Default is True.']</td>
+</tr>
+<tr>
+<td><b>authmethod</b></br>
+</td>
+<td></td>
+<td></td>
+<td> Authentication method for the Portal (BASIC, CERT). Default is BASIC. Note: when auto_config is enabled, CERT will be used if RHSM or Satellite is detected.
+</td>
+</tr>
+<tr>
+<td><b>proxy</b></br>
+</td>
+<td></td>
+<td></td>
+<td> This set an optional proxy for the insights client to connect through if the client is behind a firewall or requires a proxy. Default is unspecified (none).
+</td>
+</tr>
+<tr>
+<td><b>password</b></br>
+</td>
+<td></td>
+<td></td>
+<td> Insights basic auth password. If defined this will change, set, or remove the password in the insights configuration. To remove a password set this value to an empty string.
+</td>
+</tr>
+</table>
+
+## Examples
+```
+
+- name: Configure the insights client to register with username and password stored in Ansible Tower Custom Credential
+  insights_config:
+    username: "{{ lookup('env', INSIGHTS_USER) }}"
+    password: "{{ lookup('env', INSIGHTS_PASSWORD) }}"
+    auto_config: "{{ auto_config }}"
+    authmethod: "{{ authmethod }}"
+    proxy: "{{ insights_proxy }}"
+  become: true
+
+- name: Configure the insights client to register with RHSM and no display name
+  insights_config:
+  become: true
+
+# Note: The above example calls the insights_config module with no parameters. This is because auto_config defaults to True
+# which in turn forces the client to try RHSM (or Satellite)
+
+- name: Configure the insights client to register with RHSM and a display name
+  insights_config:
+    display_name: "{{ insights_display_name }}"
+  become: true
+
+```

--- a/docs/insights_register.md
+++ b/docs/insights_register.md
@@ -1,0 +1,93 @@
+insights_register - This module registers the insights client
+====================================
+- [Synopsis](Synopsis)
+- [Requirements](Requirements)
+- [Parameters](Parameters)
+- [Examples](Examples)
+
+## Synopsis
+'This module will check the current registration status, unregister if needed, and
+    then register the insights client (and update the display_name if needed)
+
+    '
+
+## Requirements
+''
+
+## Parameters
+
+<table>
+<tr>
+<th> Parameter </th>
+<th> Choices/Defaults </th>
+<th> Configuration </th>
+<th> Comments </th>
+</tr>
+<tr>
+<td><b>force_reregister</b></br>
+</td>
+<td></td>
+<td></td>
+<td> This option should be set to true if you wish to force a reregister of the insights-client. Note that this will remove the existing machine-id and create a new one. Only use this option if you are okay with creating a new machine-id.
+</td>
+</tr>
+<tr>
+<td><b>state</b></br>
+</td>
+<td><b>Choices:</b><br>
+- present
+- absent
+<b>Default:</b><br> 
+present</td>
+<td></td>
+<td> [u'Determines whether to register or unregister insights-client']</td>
+</tr>
+<tr>
+<td><b>display_name</b></br>
+</td>
+<td></td>
+<td></td>
+<td> This option is here to enable registering with a display_name outside of using a configuration file. Some may be used to doing it this way so I left this in as an optional parameter.
+</td>
+</tr>
+<tr>
+<td><b>insights_name</b></br>
+</td>
+<td><b>Default:</b><br> 
+insights-client</td>
+<td></td>
+<td> For now, this is just 'insights-client', but it could change in the future so having it as a variable is just preparing for that
+</td>
+</tr>
+</table>
+
+## Examples
+```
+
+# Normal Register
+- name: Register the insights client
+  insights_register:
+    state: present
+
+# Force a Reregister (for config changes, etc)
+- name: Register the insights client
+  insights_register:
+    state: present
+    force_reregister: true
+
+# Unregister
+- name: Unregister the insights client
+  insights_regsiter:
+    state: absent
+
+# Register an install of redhat-access-insights (this is not a 100% automated process)
+- name: Register redhat-access-insights
+  insights_register:
+    state: present
+    insights_name: 'redhat-access-insights'
+
+#Note: The above example for registering redhat-access-insights requires that the playbook be
+#changed to install redhat-access-insights and that redhat-access-insights is also passed into
+#the insights_config module and that the file paths be changed when using the file module
+
+```

--- a/docs/templates/docs.md.j2
+++ b/docs/templates/docs.md.j2
@@ -1,0 +1,38 @@
+{% if docs.name is defined %}{{ docs.name }}{% else %}{{ docs.module }}{% endif %} - {{ docs.short_description }}
+====================================
+- [Synopsis](Synopsis)
+- [Requirements](Requirements)
+- [Parameters](Parameters)
+- [Examples](Examples)
+
+## Synopsis
+{{ docs.description | to_nice_yaml}}
+## Requirements
+{{ docs.requirements | default('') | to_nice_yaml }}
+## Parameters
+
+<table>
+<tr>
+<th> Parameter </th>
+<th> Choices/Defaults </th>
+<th> Configuration </th>
+<th> Comments </th>
+</tr>
+{% for option in docs.options %}
+<tr>
+<td><b>{{ option }}</b></br>
+{% if docs.options[option]['required'] is defined and docs.options[option]['required'] %}<p style="color:red;font-size:75%">required</p>{% endif %}</td>
+<td>{% if docs.options[option]['choices'] is defined %}<b>Choices:</b><br>
+{{ docs.options[option]['choices'] | to_nice_yaml }}{% endif %}{% if docs.options[option]['default'] is defined %}<b>Default:</b><br> 
+{{ docs.options[option]['default'] }}{% endif %}</td>
+<td>{% if docs.options[option]['env'] is defined %}<b>env:</b><br>
+{{ docs.options[option]['env'] | to_nice_yaml }}{% endif %}</td>
+<td> {{ docs.options[option]['description'] }}</td>
+</tr>
+{% endfor %}
+</table>
+
+## Examples
+```
+{{ examples }}
+```


### PR DESCRIPTION
This PR adds dedicated doc pages for modules and plugins. Docs are created automatically using the create_docs playbook in the docs directory