### PR TITLE
Compliance Role

### DIFF
--- a/roles/compliance/README.md
+++ b/roles/compliance/README.md
@@ -1,0 +1,61 @@
+compliance
+========
+
+Installs, configures, and runs [OpenSCAP](https://www.open-scap.org) compliance on a system connected to the [Red Hat Insights service](https://access.redhat.com/documentation/en-us/red_hat_insights/).  This role is intended to work on Red Hat Enterprise Linux.
+
+Requirements
+------------
+- The Insights client must be installed and configured prior to using the compliance service. See the [insights_client](../insights_client/README.md) role for automated deployment and configuration of the client. 
+
+- The host must me configured in the [Insights portal](https://cloud.redhat.com/insights/compliance) prior to running a compliance scan.
+
+Role Variables / Configuration
+--------------
+
+N/A
+
+Dependencies
+------------
+
+N/A
+
+Example Playbook
+----------------
+
+The role can be used in three ways from a playbook, install only, run only, or all-in-one. The all-in-one is most common and recommend usage as it will ensure all pre-requisites are met prior to running a compliance scan.
+
+```
+---
+- hosts: all
+  
+  tasks:
+  - name: insights compliance
+    import_role:
+      name: redhat.insights.compliance
+```
+
+If you only wish to install pre-requisites without running a compliance scan the role may be used with only the "install" tasks as shown in the example below. 
+
+```
+---
+- hosts: all
+
+  tasks:
+  - name: install insights compliance
+    import_role:
+      name: redhat.insights.compliance
+      tasks_from: install
+```
+
+To speed up compliance scans after installation of prerequisites, the role may be run with only the "run" tasks as shown in the example below. Use caution when using this method as it can cause hosts to fail or become inconsistent with other hosts since prerequisites are not being checked and met prior to running a scan.
+
+```
+---
+- hosts: all
+
+  tasks:
+  - name: run insights compliance
+    import_role:
+      name: redhat.insights.compliance
+      tasks_from: run
+```

--- a/roles/compliance/meta/main.yml
+++ b/roles/compliance/meta/main.yml
@@ -1,0 +1,17 @@
+---
+galaxy_info:
+  author: Red Hat, Inc
+  description: Install and configure Red Hat Insights Client
+  company: Red Hat, Inc.
+  license: Apache License 2.0
+  min_ansible_version: 1.2
+  platforms:
+    - name: EL
+      versions:
+        - 6
+        - 7
+        - 8
+  categories:
+    - packaging
+    - system
+  dependencies: []

--- a/roles/compliance/tasks/install.yml
+++ b/roles/compliance/tasks/install.yml
@@ -5,3 +5,4 @@
       - openscap
       - scap-security-guide
       - openscap-scanner
+    state: latest

--- a/roles/compliance/tasks/install.yml
+++ b/roles/compliance/tasks/install.yml
@@ -1,0 +1,7 @@
+---
+- name: install openscap packages
+  yum:
+    name:
+      - openscap
+      - scap-security-guide
+      - openscap-scanner

--- a/roles/compliance/tasks/main.yml
+++ b/roles/compliance/tasks/main.yml
@@ -1,3 +1,8 @@
 ---
+- name: check for insights configuration
+  assert:
+    that: ansible_local.insights is defined
+    fail_msg: Unable to find insights fact. Have you installed the insights client?
+
 - include_tasks: install.yml
 - include_tasks: run.yml

--- a/roles/compliance/tasks/main.yml
+++ b/roles/compliance/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- include_tasks: install.yml
+- include_tasks: run.yml

--- a/roles/compliance/tasks/run.yml
+++ b/roles/compliance/tasks/run.yml
@@ -1,0 +1,3 @@
+---
+- name: run compliance scan
+  command: insights-client --compliance

--- a/roles/compliance/tests/compliance.yml
+++ b/roles/compliance/tests/compliance.yml
@@ -1,0 +1,7 @@
+---
+- hosts: all
+  
+  tasks:
+  - name: insights compliance
+    import_role:
+      name: redhat.insights.compliance

--- a/roles/compliance/tests/install-only.yml
+++ b/roles/compliance/tests/install-only.yml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+
+  tasks:
+  - name: install insights compliance
+    import_role:
+      name: redhat.insights.compliance
+      tasks_from: install

--- a/roles/compliance/tests/run-only.yml
+++ b/roles/compliance/tests/run-only.yml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+
+  tasks:
+  - name: run insights compliance
+    import_role:
+      name: redhat.insights.compliance
+      tasks_from: run


### PR DESCRIPTION
Add a role to run Insights compliance scans. It can be used to install required packages and run OpenSCAP scan.
