### PR TITLE
ansible_host variable

### DIFF
--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -147,10 +147,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         for host in results:
             host_name = self.inventory.add_host(host['display_name'])
             for item in host.keys():
-                if host[item] is None:
-                    self.inventory.set_variable(host_name, item, host['fqdn'])
-                else:
-                    self.inventory.set_variable(host_name, vars_prefix + item, host[item])
+                self.inventory.set_variable(host_name, vars_prefix + item, host[item])
 
             if get_patches:
                 if host_name in patching.keys():

--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -147,12 +147,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         for host in results:
             host_name = self.inventory.add_host(host['display_name'])
             for item in host.keys():
-                if item != 'ansible_host':
-                    self.inventory.set_variable(host_name, vars_prefix + item, host[item])
-                elif host[item] is None:
+                if host[item] is None:
                     self.inventory.set_variable(host_name, item, host['fqdn'])
                 else:
-                    self.inventory.set_variable(host_name, item, host[item])
+                    self.inventory.set_variable(host_name, vars_prefix + item, host[item])
 
             if get_patches:
                 if host_name in patching.keys():


### PR DESCRIPTION
This PR addresses issue #5 where the `ansible_host` variable from Insights was always set as `ansible_host` variable in inventory. This causes conflict when using multiple inventory sources and did not allow the user to control which source defines `ansible_host`. For example, if using an inventory from aws which would allow the user to choose the public or private IP for the value of `ansible_host` it would conflict or be overridden by the Insights inventory.