### PR TITLE
fix(docs): Set proper defaults for force_reregister

### DIFF
--- a/plugins/modules/insights_register.py
+++ b/plugins/modules/insights_register.py
@@ -46,6 +46,7 @@ options:
       This option should be set to true if you wish to force a reregister of the insights-client.
       Note that this will remove the existing machine-id and create a new one. Only use this option
       if you are okay with creating a new machine-id.
+    default: false
     required: false
     type: bool
 


### PR DESCRIPTION
There was no default set for `force_reregister` in the docs, so I added it for the sanity tests.

Signed-off-by: Stephen Adams <tsadams@gmail.com>