### PR TITLE
Add fixes for installing from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -389,5 +389,4 @@ $RECYCLE.BIN/
 # End of https://www.gitignore.io/api/git,linux,pydev,python,windows,pycharm+all,jupyternotebook,vim,webstorm,emacs,dotenv
 
 # Collection Artifacts
-galaxy.yml
 *.tar.gz

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -49,10 +49,10 @@ False</td>
 <td><b>plugin</b></br>
 <p style="color:red;font-size:75%">required</p></td>
 <td><b>Choices:</b><br>
-- redhat.insights.insights
+- redhatinsights.insights.insights
 </td>
 <td></td>
-<td> the name of this plugin, it should always be set to 'redhat.insights.insights' for this plugin to recognize it as it's own.</td>
+<td> the name of this plugin, it should always be set to 'redhatinsights.insights.insights' for this plugin to recognize it as it's own.</td>
 </tr>
 <tr>
 <td><b>user</b></br>
@@ -86,10 +86,10 @@ insights_</td>
 ```
 
 # basic example using environment vars for auth
-plugin: redhat.insights.insights
+plugin: redhatinsights.insights.insights
 
 # create groups for patching
-plugin: redhat.insights.insights
+plugin: redhatinsights.insights.insights
 get_patches: yes
 groups:
   patching: insights_patching.enabled
@@ -99,7 +99,7 @@ groups:
   enhancement_patch: insights_patching.rhea_count > 0
 
 # filter host by tags and create groups from tags
-plugin: redhat.insights.insights
+plugin: redhatinsights.insights.insights
 get_tags: True
 filter_tags:
   - insights-client/env=prod

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,14 +1,13 @@
 ---
-namespace: {{ collection_namespace }}
-name: {{ collection_name }}
-version: {{ collection_version }}
+namespace: redhatinsights
+name: insights
+version: 0.0.1-devel
 readme: README.md
 authors:
 - Will Tome (@wtome)
 description: Ansible Collection for Red Hat insights
-repository: {{ collection_repo }}
+repository: https://github.com/redhatinsights/ansible-collections-insights
 build_ignore:
-- galaxy.yml.j2
 - release.yml
 - .gitignore
 - changelogs/.plugin-cache.yaml

--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -14,9 +14,9 @@ DOCUMENTATION = '''
         - constructed
     options:
       plugin:
-        description: the name of this plugin, it should always be set to 'redhat.insights.insights' for this plugin to recognize it as it's own.
+        description: the name of this plugin, it should always be set to 'redhatinsights.insights.insights' for this plugin to recognize it as it's own.
         required: True
-        choices: ['redhat.insights.insights']
+        choices: ['redhatinsights.insights.insights']
       user:
         description: Red Hat username
         required: True
@@ -61,10 +61,10 @@ DOCUMENTATION = '''
 
 EXAMPLES = '''
 # basic example using environment vars for auth
-plugin: redhat.insights.insights
+plugin: redhatinsights.insights.insights
 
 # create groups for patching
-plugin: redhat.insights.insights
+plugin: redhatinsights.insights.insights
 get_patches: yes
 groups:
   patching: insights_patching.enabled
@@ -74,7 +74,7 @@ groups:
   enhancement_patch: insights_patching.rhea_count > 0
 
 # filter host by tags and create groups from tags
-plugin: redhat.insights.insights
+plugin: redhatinsights.insights.insights
 get_tags: True
 filter_tags:
   - insights-client/env=prod
@@ -99,7 +99,7 @@ except ImportError:
 class InventoryModule(BaseInventoryPlugin, Constructable):
     ''' Host inventory parser for ansible using foreman as source. '''
 
-    NAME = 'redhat.insights.insights'
+    NAME = 'redhatinsights.insights.insights'
 
     def get_patches(self, stale):
         query = "api/patch/v1/systems?filter[stale]=%s" % stale

--- a/release.yml
+++ b/release.yml
@@ -5,9 +5,7 @@
   connection: local
   vars:
     collection_namespace: "{{ namespace  | lower }}"
-    collection_name: insights
     collection_version: "{{ github_tag.split('/')[-1] | regex_search('(\\d.\\d.\\d.*)') }}"
-    collection_repo: https://github.com/redhatinsights/ansible-collections-insights
     api_key: undef
 
   tasks:
@@ -16,36 +14,49 @@
         - name: fix inventory plugin
           replace:
             path: "{{ playbook_dir }}/plugins/inventory/insights.py"
-            regexp: redhat.insights
-            replace: "{{ collection_namespace }}.{{collection_name }}"
+            regexp: redhatinsights.insights
+            replace: "{{ collection_namespace }}.insights"
+
+        - name: fix inventory plugin docs
+          replace:
+            path: "{{ playbook_dir }}/docs/inventory.md"
+            regexp: redhatinsights.insights
+            replace: "{{ collection_namespace }}.insights"
 
         - name: fix role test
           replace:
             path: "{{ playbook_dir }}/roles/insights_client/tests/example-insights-client-playbook.yml"
-            regexp: redhat.insights
-            replace: "{{ collection_namespace }}.{{collection_name }}"
+            regexp: redhatinsights.insights
+            replace: "{{ collection_namespace }}.insights"
 
-    - name: create galaxy.yml
-      template:
-        src: "{{ playbook_dir}}/galaxy.yml.j2"
-        dest: "{{ playbook_dir }}/galaxy.yml"
+    - name: update galaxy.yml version
+      replace:
+        path: "{{ playbook_dir }}/galaxy.yml"
+        regexp: "0.0.1-devel"
+        replace: "{{ collection_version }}"
+
+    - name: update galaxy.yml namespace
+      replace:
+        path: "{{ playbook_dir }}/galaxy.yml"
+        regexp: "namespace: redhatinsights"
+        replace: "{{ collection_namespace }}"
 
     - name: build collection
       command:
         cmd: ansible-galaxy collection build
         chdir: "{{ playbook_dir }}"
-        creates: "{{ playbook_dir }}/{{ collection_namespace }}-{{ collection_name }}-{{ collection_version }}.tar.gz"
+        creates: "{{ playbook_dir }}/{{ collection_namespace }}-insights-{{ collection_version }}.tar.gz"
       tags: build
 
     - name: install collection
       command:
-        cmd: "ansible-galaxy collection install {{ collection_namespace }}-{{ collection_name }}-{{ collection_version }}.tar.gz -p ~/.ansible/collections/"
+        cmd: "ansible-galaxy collection install {{ collection_namespace }}-insights-{{ collection_version }}.tar.gz -p ~/.ansible/collections/"
         chdir: "{{ playbook_dir }}"
       tags: install
 
     - name: publish collection
       command:
-        cmd: "ansible-galaxy collection publish --api-key={{ api_key }} {{ collection_namespace }}-{{ collection_name }}-{{ collection_version }}.tar.gz"
+        cmd: "ansible-galaxy collection publish --api-key={{ api_key }} {{ collection_namespace }}-insights-{{ collection_version }}.tar.gz"
         chdir: "{{ playbook_dir }}"
       tags: publish
 


### PR DESCRIPTION
This removes the galaxy.yml templating, and flips some of the
templated values to the namespace used on galaxy.ansible.com.