### PR TITLE
Remove testinfra / add bindep.txt file

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,1 @@
+python38-requests [platform:centos-8 platform:rhel-8]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 requests
-testinfra


### PR DESCRIPTION
Testinfra isn't needed by the collections direct, but for testing. We
can remove it from the final image of EEs.

We can also install python38-requests from the distro RPM packages, so
lets add that too.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>