### PR TITLE
add scheme and server

### DIFF
--- a/galaxy.yml.j2
+++ b/galaxy.yml.j2
@@ -1,12 +1,12 @@
 ---
-namespace: {{ collection_namespace }}
-name: {{ collection_name }}
-version: {{ collection_version }}
+namespace: test
+name: insights
+version: 1
 readme: README.md
 authors:
-- Will Tome (@wtome)
-description: Ansible Collection for Red Hat insights
-repository: {{ collection_repo }}
+- jmorenas
+description: Ansible Collection for Red Hat insights test
+repository: https://github.com/jangel97/ansible-collections-insights.git
 build_ignore:
 - galaxy.yml.j2
 - release.yml

--- a/galaxy.yml.j2
+++ b/galaxy.yml.j2
@@ -1,12 +1,12 @@
 ---
-namespace: test
-name: insights
-version: 1
+namespace: {{ collection_namespace }}
+name: {{ collection_name }}
+version: {{ collection_version }}
 readme: README.md
 authors:
-- jmorenas
-description: Ansible Collection for Red Hat insights test
-repository: https://github.com/jangel97/ansible-collections-insights.git
+- Will Tome (@wtome)
+description: Ansible Collection for Red Hat insights
+repository: {{ collection_repo }}
 build_ignore:
 - galaxy.yml.j2
 - release.yml

--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -103,7 +103,7 @@ except ImportError:
 class InventoryModule(BaseInventoryPlugin, Constructable):
     ''' Host inventory parser for ansible using foreman as source. '''
 
-    NAME = 'redhat.insights.insights'
+    NAME = 'test.insights.insights'
 
     def get_patches(self, stale):
         query = "api/patch/v1/systems?filter[stale]=%s" % stale

--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -88,7 +88,7 @@ keyed_groups:
 '''
 
 
-from ansible.plugins.inventory import BaseInventoryPlugin, to_safe_group_name, Constructable
+from ansible.plugins.inventory import BaseInventoryPlugin, Constructable
 from ansible.errors import AnsibleError
 from distutils.version import LooseVersion
 

--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -120,7 +120,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 results += response.json()['data']
                 next_page = response.json()['links']['next']
                 if next_page:
-                    #url = next_page
                     url = url =  "%s/%s" % (self.server, next_page)
                 else:
                     url = None

--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -120,7 +120,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 results += response.json()['data']
                 next_page = response.json()['links']['next']
                 if next_page:
-                    url = next_page
+                    #url = next_page
+                    url = url =  "%s/%s" % (self.server, next_page)
                 else:
                     url = None
 

--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -103,7 +103,7 @@ except ImportError:
 class InventoryModule(BaseInventoryPlugin, Constructable):
     ''' Host inventory parser for ansible using foreman as source. '''
 
-    NAME = 'test.insights.insights'
+    NAME = 'redhat.insights.insights'
 
     def get_patches(self, stale):
         query = "api/patch/v1/systems?filter[stale]=%s" % stale

--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -120,7 +120,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 results += response.json()['data']
                 next_page = response.json()['links']['next']
                 if next_page:
-                    url = url =  "%s/%s" % (self.server, next_page)
+                   url =  "%s/%s" % (self.server, next_page)
                 else:
                     url = None
 


### PR DESCRIPTION
Hi,

I tested in my environment and this would solve https://github.com/RedHatInsights/ansible-collections-insights/issues/25

Error:
```
No connection adapters were found for '/api/patch/v1/systems?offset=20&limit=20&filter[stale]=eq:True&sort=-last_upload'"
```
Error happens when iterating for next page (https://github.com/RedHatInsights/ansible-collections-insights/blob/master/plugins/inventory/insights.py#L123), the var "url" gets overwritten by the "next_page" var, which does not include  the scheme "https" and the server name "console.redhat.com" , and so this makes the HTTP request fail. 

In order to solve this, I suggest concatenating scheme and server by doing following slight modification: https://github.com/RedHatInsights/ansible-collections-insights/pull/29/files#diff-c5612de53a1719cc5997cb7e1118b7b4ee73aa564cf4060dd40145c360e6e237R123

Please, let me know if you think this change makes sense and thank you in advance.

Kind regards,
