### PR TITLE
Fixes #RHINENG-765 - fixed incorrectly generating url

### DIFF
--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -246,7 +246,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 if per_page * (page - 1) + count < total:
                     hosts_url = "%s&page=%s" % (url, (page + 1))
                     if len(filter_tags) > 0:
-                        hosts_url = "%s&tags=%s" % (url, '&tags='.join(filter_tags))
+                        hosts_url = "%s&tags=%s" % (hosts_url, '&tags='.join(filter_tags))
                 else:
                     hosts_url = None
 

--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -230,8 +230,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         self.auth = requests.auth.HTTPBasicAuth(self.get_option('user'), self.get_option('password'))
         self.session = requests.Session()
 
-        while url:
-            response = self.session.get(url, auth=self.auth, headers=self.headers)
+        hosts_url = url
+        while hosts_url:
+            response = self.session.get(hosts_url, auth=self.auth, headers=self.headers)
 
             if response.status_code != 200:
                 raise AnsibleError("http error (%s): %s" %
@@ -243,11 +244,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 per_page = response.json()['per_page']
                 page = response.json()['page']
                 if per_page * (page - 1) + count < total:
-                    url = "%s&page=%s" % (url, (page + 1))
+                    hosts_url = "%s&page=%s" % (url, (page + 1))
                     if len(filter_tags) > 0:
-                        url = "%s&tags=%s" % (url, '&tags='.join(filter_tags))
+                        hosts_url = "%s&tags=%s" % (url, '&tags='.join(filter_tags))
                 else:
-                    url = None
+                    hosts_url = None
 
         if get_patching_info:
             stale_patches = self.get_patches(stale=True,get_system_advisories=get_system_advisories,get_system_packages=get_system_packages,filter_tags=filter_tags)


### PR DESCRIPTION
fixes - https://github.com/RedHatInsights/ansible-collections-insights/issues/48 
This can be improved more but here is a quick fix. Basically URL is generating incorrectly. We are appending to the same old url because of which url gets bigger than 4096 characters.
Example - 
```
https://console.redhat.com/api/inventory/v1/hosts?&page=2&page=3&page=4&page=5&page=6&page=7&page=8&page=9&page=10&page=11
```