### PR TITLE
CI: update & fix to run properly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -50,20 +50,49 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
         with:
+          fetch-depth: 0
           path: ansible_collections/redhat/insights
 
-      - name: Set up Python ${{ matrix.ansible }}
-        uses: actions/setup-python@v4
+      - name: Check out the branch
+        run: |
+          # Create a branch for the current HEAD, which happens to be a merge commit
+          git -C ansible_collections/redhat/insights checkout -b 'pull-request-${{ github.event.pull_request.number }}'
+
+          # Name the target branch
+          git -C ansible_collections/redhat/insights branch '${{
+            github.event.pull_request.base.ref
+          }}' --track 'origin/${{
+            github.event.pull_request.base.ref
+          }}'
+
+          # Show branch information
+          git -C ansible_collections/redhat/insights branch -vv
+
+      - name: Get git version
+        id: git-version
+        run: |
+          export version=$(git -C ansible_collections/redhat/insights describe --tags | grep -Po '\d+\.\d+\.\d+')
+          echo "git_version=$version" >> $GITHUB_OUTPUT
+
+      - name: Generate galaxy.yml
+        uses: cuchi/jinja2-action@v1.2.0
         with:
-          python-version: ${{ matrix.python }}
+          template: ansible_collections/redhat/insights/galaxy.yml.j2
+          output_file: ansible_collections/redhat/insights/galaxy.yml
+          strict: true
+          variables: |
+            collection_name=insights
+            collection_namespace=${{ github.repository_owner }}
+            collection_repo=https://github.com/${{ github.repository }}
+            collection_version=${{ steps.git-version.outputs.git_version }}
 
-      # Install the head of the given branch (devel, stable-2.10)
-      - name: Install ansible-base (${{ matrix.ansible }})
-        run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
-
-      # run ansible-test sanity inside of Docker.
-      # The docker container has all the pinned dependencies that are required.
-      # Explicity specify the version of Python we want to test
       - name: Run sanity tests
-        run: ansible-test sanity --docker -v --color --python ${{ matrix.python }}
-        working-directory: ./ansible_collections/redhat/insights
+        uses: ansible-community/ansible-test-gh-action@release/v1
+        with:
+          ansible-core-github-repository-slug: ${{ contains(fromJson('["2.9", "2.10", "2.11"]'), matrix.ansible) && 'felixfontein/ansible' || 'ansible/ansible' }}
+          ansible-core-version: stable-${{ matrix.ansible }}
+          collection-src-directory: ${{ github.workspace }}/ansible_collections/redhat/insights
+          coverage: ${{ github.event_name == 'schedule' && 'always' || 'never' }}
+          pull-request-change-detection: 'true'
+          target-python-version: ${{ matrix.python }}
+          testing-type: sanity

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -1,8 +1,10 @@
 name: CI
 on:
-# Run CI against all pushes (direct commits) and Pull Requests
-- push
-- pull_request
+  # Run EOL CI against all pushes (direct commits, also merged PRs), Pull Requests
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
 

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -16,6 +16,7 @@ jobs:
   sanity:
     name: Sanity (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }})
     strategy:
+      fail-fast: false
       matrix:
         ansible:
           # It's important that Sanity is tested against all stable-X.Y branches

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -37,12 +37,12 @@ jobs:
       # .../ansible_collections/NAMESPACE/COLLECTION_NAME/
 
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ansible_collections/redhat/insights
 
       - name: Set up Python ${{ matrix.ansible }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -19,18 +19,22 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          # It's important that Sanity is tested against all stable-X.Y branches
-          # Testing against `devel` may fail as new tests are added.
-        # - stable-2.9 # Only if your collection supports Ansible 2.9
-          - stable-2.11
-          - stable-2.10
-          - devel
+          - ''
         python:
-          - 2.7
-          - 3.7
-          - 3.8
+          - ''
         exclude:
-          - python: 3.8  # blocked by ansible/ansible#70155
+          - ansible: ''
+        include:
+          - ansible: '2.9'
+            python: '2.7'
+          - ansible: '2.10'
+            python: '2.7'
+          - ansible: '2.11'
+            python: '2.7'
+          - ansible: '2.11'
+            python: '3.6'
+          - ansible: '2.11'
+            python: '3.9'
     # Ansible-test on various stable branches does not yet work well with cgroups v2.
     # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
     # image for these stable branches. The list of branches where this is necessary will

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -31,7 +31,13 @@ jobs:
           - 3.8
         exclude:
           - python: 3.8  # blocked by ansible/ansible#70155
-    runs-on: ubuntu-latest
+    # Ansible-test on various stable branches does not yet work well with cgroups v2.
+    # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
+    # image for these stable branches. The list of branches where this is necessary will
+    # shrink over time, check out https://github.com/ansible-collections/news-for-maintainers/issues/28
+    # for the latest list.
+    runs-on: >-
+      ${{ (contains(fromJson('["2.9", "2.10", "2.11"]'), matrix.ansible) || contains(fromJson('["2.7", "3.5", "3.6"]'), matrix.python)) && 'ubuntu-20.04' || 'ubuntu-latest' }}
     steps:
 
       # ansible-test requires the collection to be in a directory in the form

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.10,<2.11"
+requires_ansible: ">=2.10,<2.13"

--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -254,8 +254,18 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                     hosts_url = None
 
         if get_patching_info:
-            stale_patches = self.get_patches(stale=True, get_system_advisories=get_system_advisories, get_system_packages=get_system_packages, filter_tags=filter_tags)
-            patches = self.get_patches(stale=False, get_system_advisories=get_system_advisories, get_system_packages=get_system_packages, filter_tags=filter_tags)
+            stale_patches = self.get_patches(
+                stale=True,
+                get_system_advisories=get_system_advisories,
+                get_system_packages=get_system_packages,
+                filter_tags=filter_tags
+            )
+            patches = self.get_patches(
+                stale=False,
+                get_system_advisories=get_system_advisories,
+                get_system_packages=get_system_packages,
+                filter_tags=filter_tags
+            )
             patching_results = patches + stale_patches
             patching = {}
 

--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -285,7 +285,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             systems_by_id_list_split=[systems_by_id_list[i:i + chunk_size] for i in range(0, len(systems_by_id_list), chunk_size)]
             for items in systems_by_id_list_split:
                 partial_system_tags = self.get_tags(items)
-                system_tags = {**system_tags, **partial_system_tags}
+                system_tags.update(partial_system_tags)
 
         for uuid in systems_by_id:
             host_name = systems_by_id[uuid]

--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -114,27 +114,30 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
     NAME = 'redhat.insights.insights'
 
-    def get_patches(self, stale, get_system_advisories,get_system_packages,filter_tags):
-        def get_system_patching_info(system_id,info):
+    def get_patches(self, stale, get_system_advisories, get_system_packages, filter_tags):
+        def get_system_patching_info(system_id, info):
             query = "api/patch/v1/export/systems"
             url = "%s/%s/%s/%s" % (self.server, query, system_id, info)
             response = self.session.get(url, auth=self.auth, headers=self.headers)
             if response.status_code != 200:
                 raise AnsibleError("http error (%s): %s" %
-                                    (response.status_code, response.text))
+                                   (response.status_code, response.text))
             system_patching_info = response.json()
             return system_patching_info
-        def format_url(server,api_call,filter_tags):
+
+        def format_url(server, api_call, filter_tags):
             url = "%s/%s" % (server, api_call)
             if len(filter_tags) > 0:
                 url = "%s&tags=%s" % (url, '&tags='.join(filter_tags))
             return url
-        def add_patching_data(results,patching_info):
+
+        def add_patching_data(results, patching_info):
             for result in results:
                 id = result['id']
-                patching_info_result = get_system_patching_info(id,patching_info)
+                patching_info_result = get_system_patching_info(id, patching_info)
                 result['attributes'][patching_info] = patching_info_result
             return results
+
         query = "api/patch/v1/systems?filter[stale]=%s" % stale
         url = format_url(self.server, query, filter_tags)
         results = []
@@ -149,11 +152,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 if next_page:
                     url = format_url(self.server, next_page, filter_tags)
                 else:
-                    url = None 
+                    url = None
         if get_system_advisories:
-            results = add_patching_data(results,"advisories")
+            results = add_patching_data(results, "advisories")
         if get_system_packages:
-            results = add_patching_data(results,"packages")
+            results = add_patching_data(results, "packages")
         return results
 
     def get_tags(self, ids):
@@ -251,8 +254,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                     hosts_url = None
 
         if get_patching_info:
-            stale_patches = self.get_patches(stale=True,get_system_advisories=get_system_advisories,get_system_packages=get_system_packages,filter_tags=filter_tags)
-            patches = self.get_patches(stale=False,get_system_advisories=get_system_advisories,get_system_packages=get_system_packages,filter_tags=filter_tags)
+            stale_patches = self.get_patches(stale=True, get_system_advisories=get_system_advisories, get_system_packages=get_system_packages, filter_tags=filter_tags)
+            patches = self.get_patches(stale=False, get_system_advisories=get_system_advisories, get_system_packages=get_system_packages, filter_tags=filter_tags)
             patching_results = patches + stale_patches
             patching = {}
 
@@ -281,8 +284,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         if get_tags:
             system_tags = {}
             systems_by_id_list = list(systems_by_id.keys())
-            chunk_size=20
-            systems_by_id_list_split=[systems_by_id_list[i:i + chunk_size] for i in range(0, len(systems_by_id_list), chunk_size)]
+            chunk_size = 20
+            systems_by_id_list_split = [systems_by_id_list[i:i + chunk_size] for i in range(0, len(systems_by_id_list), chunk_size)]
             for items in systems_by_id_list_split:
                 partial_system_tags = self.get_tags(items)
                 system_tags.update(partial_system_tags)

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,1 +1,0 @@
-roles/insights_client/files/insights.fact shebang

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,1 +1,4 @@
 roles/insights_client/files/insights.fact shebang
+plugins/inventory/insights.py import-2.7 # needs 'requests'
+plugins/inventory/insights.py import-3.6 # needs 'requests'
+plugins/inventory/insights.py import-3.9 # needs 'requests'


### PR DESCRIPTION
The current CI (the sanity test, in particular) is broken:
- some actions changed behaviour and do not work anymore
- the latest runners are too new for certain versions of Ansible & Python
- and few more problems

To fix this, massage a bit the existing code and CI bits:
- consider Ansible 2.12 as supported; it was already supposed to be tested, so most likely it was intended to be supported
- remove a Python 3.5+ bit, making all the bits usable with Python 2.7+
- fix pylint issues: whitespace issues, long lines
- update the ignores for the sanity test to match the current situation
- do not run CI jobs on push for branches different than `master`, leaving them only for PR events
- update the already used actions to latest versions
- allow all the jobs to run, instead of cancelling all after the first failure
- use `ubuntu-20.04` as runner for old versions of Python or Ansible
- use https://github.com/ansible-community/ansible-test-gh-action for running the sanity test, even if we need some manual tweaks due to #19
- add a dependabot configuration to help us ensuring the used action are up-to-date

See the individual commits for more details on each change.

