### PR TITLE
Support more Ansible versions

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -39,6 +39,10 @@ jobs:
             python: '3.8'
           - ansible: '2.12'
             python: '3.10'
+          - ansible: '2.13'
+            python: '3.8'
+          - ansible: '2.13'
+            python: '3.10'
     # Ansible-test on various stable branches does not yet work well with cgroups v2.
     # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
     # image for these stable branches. The list of branches where this is necessary will

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -35,6 +35,10 @@ jobs:
             python: '3.6'
           - ansible: '2.11'
             python: '3.9'
+          - ansible: '2.12'
+            python: '3.8'
+          - ansible: '2.12'
+            python: '3.10'
     # Ansible-test on various stable branches does not yet work well with cgroups v2.
     # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
     # image for these stable branches. The list of branches where this is necessary will

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -47,6 +47,10 @@ jobs:
             python: '3.9'
           - ansible: '2.14'
             python: '3.11'
+          - ansible: '2.15'
+            python: '3.9'
+          - ansible: '2.15'
+            python: '3.11'
     # Ansible-test on various stable branches does not yet work well with cgroups v2.
     # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
     # image for these stable branches. The list of branches where this is necessary will

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -43,6 +43,10 @@ jobs:
             python: '3.8'
           - ansible: '2.13'
             python: '3.10'
+          - ansible: '2.14'
+            python: '3.9'
+          - ansible: '2.14'
+            python: '3.11'
     # Ansible-test on various stable branches does not yet work well with cgroups v2.
     # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
     # image for these stable branches. The list of branches where this is necessary will

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.9,<2.14"
+requires_ansible: ">=2.9,<2.15"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.9,<2.13"
+requires_ansible: ">=2.9,<2.14"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.9,<2.15"
+requires_ansible: ">=2.9,<2.16"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.10,<2.13"
+requires_ansible: ">=2.9,<2.13"

--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -3,7 +3,6 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
     name: insights
-    plugin_type: inventory
     short_description: insights inventory source
     requirements:
         - requests >= 1.1
@@ -15,16 +14,16 @@ DOCUMENTATION = '''
     options:
       plugin:
         description: the name of this plugin, it should always be set to 'redhat.insights.insights' for this plugin to recognize it as it's own.
-        required: True
+        required: true
         choices: ['redhat.insights.insights']
       user:
         description: Red Hat username
-        required: True
+        required: true
         env:
             - name: INSIGHTS_USER
       password:
         description: Red Hat password
-        required: True
+        required: true
         env:
             - name: INSIGHTS_PASSWORD
       server:
@@ -38,6 +37,7 @@ DOCUMENTATION = '''
         description: Choose what hosts to return, based on staleness
         default: [ 'fresh', 'stale', 'unknown' ]
         type: list
+        elements: str
       registered_with:
         description: Filter out any host not registered with the specified service
         default: insights
@@ -48,29 +48,30 @@ DOCUMENTATION = '''
         type: str
       get_patches:
         description: Fetch patching information for each system.
-        required: False
+        required: false
         type: bool
-        default: False
+        default: false
       get_system_advisories:
         description: Fetch advisories information for each system. If enabled will also fetch pathching information.
-        required: False
+        required: false
         type: bool
-        default: False
+        default: false
       get_system_packages:
         description: Fetch packages information for each system. If enabled will also fetch pathching information.
-        required: False
+        required: false
         type: bool
-        default: False
+        default: false
       get_tags:
         description: Fetch tag data for each system.
-        required: False
+        required: false
         type: bool
-        default: False
+        default: false
       filter_tags:
         description: Filter hosts with given tags
-        required: False
+        required: false
         type: list
         default: []
+        elements: str
 '''
 
 EXAMPLES = '''
@@ -79,7 +80,7 @@ plugin: redhat.insights.insights
 
 # create groups for patching
 plugin: redhat.insights.insights
-get_patches: yes
+get_patches: true
 groups:
   patching: insights_patching.enabled
   stale: insights_patching.stale
@@ -89,7 +90,7 @@ groups:
 
 # filter host by tags and create groups from tags
 plugin: redhat.insights.insights
-get_tags: True
+get_tags: true
 filter_tags:
   - insights-client/env=prod
 keyed_groups:

--- a/plugins/modules/insights_register.py
+++ b/plugins/modules/insights_register.py
@@ -103,7 +103,7 @@ def run_module():
     module_args = dict(
         state=dict(choices=['present', 'absent'], default='present'),
         insights_name=dict(type='str', required=False, default='insights-client'),
-        display_name=dict(type='str', required=False, default=''),
+        display_name=dict(type='str', required=False, default=None),
         force_reregister=dict(type='bool', required=False, default=False)
     )
 

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,0 +1,3 @@
+roles/insights_client/files/insights.fact shebang
+plugins/inventory/insights.py import-3.8 # needs 'requests'
+plugins/inventory/insights.py import-3.10 # needs 'requests'

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,0 +1,4 @@
+roles/insights_client/files/insights.fact shebang
+plugins/inventory/insights.py import-3.8 # needs 'requests'
+plugins/inventory/insights.py import-3.10 # needs 'requests'
+plugins/inventory/insights.py validate-modules:missing-gplv3-license # the plugin is licensed as Apache 2.0

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,0 +1,4 @@
+roles/insights_client/files/insights.fact shebang
+plugins/inventory/insights.py import-3.9 # needs 'requests'
+plugins/inventory/insights.py import-3.11 # needs 'requests'
+plugins/inventory/insights.py validate-modules:missing-gplv3-license # the plugin is licensed as Apache 2.0

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,0 +1,4 @@
+roles/insights_client/files/insights.fact shebang
+plugins/inventory/insights.py import-3.9 # needs 'requests'
+plugins/inventory/insights.py import-3.11 # needs 'requests'
+plugins/inventory/insights.py validate-modules:missing-gplv3-license # the plugin is licensed as Apache 2.0


### PR DESCRIPTION
Add support, even if tested only with sanity test, for Ansible versions from 2.9 (included) up to Ansible 2.15 (included).

The matrix of the support Ansible+Python combinations is taken from:
https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix

The additional changes are:
- fix the documentation of the inventory plugin a bit
- fix the default of the `display_name` parameter of the `insights_register` module
- add ignores for the missing GPLv3 header in the inventory plugin: the expectation of Ansible is that plugins are licensed as GPLv3, and
  > the MAIN use of `ansible-test` is to test ansible-core
  
  [1]

[1] https://github.com/ansible/ansible/issues/67032