### PR TITLE
inventory: gracefully handle the lack of python-requests

### DIFF
--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -100,11 +100,14 @@ keyed_groups:
 
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable
 from ansible.errors import AnsibleError
+from ansible.module_utils.six import raise_from
 
 try:
     import requests
-except ImportError:
-    raise AnsibleError('This script requires python-requests')
+except ImportError as exc:
+    REQUESTS_IMPORT_ERROR = exc
+else:
+    REQUESTS_IMPORT_ERROR = None
 
 
 class InventoryModule(BaseInventoryPlugin, Constructable):
@@ -200,6 +203,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         return valid
 
     def parse(self, inventory, loader, path, cache=True):
+        if REQUESTS_IMPORT_ERROR:
+            raise_from(AnsibleError('`requests` must be installed to use this plugin'), REQUESTS_IMPORT_ERROR)
         super(InventoryModule, self).parse(inventory, loader, path)
         self._read_config_data(path)
 

--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -5,7 +5,7 @@ DOCUMENTATION = '''
     name: insights
     short_description: insights inventory source
     requirements:
-        - requests >= 1.1
+        - requests
     description:
         - Get inventory hosts from the console.redhat.com inventory service.
         - Uses a YAML configuration file that ends with ``insights.(yml|yaml)``.
@@ -100,14 +100,11 @@ keyed_groups:
 
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable
 from ansible.errors import AnsibleError
-from distutils.version import LooseVersion
 
 try:
     import requests
-    if LooseVersion(requests.__version__) < LooseVersion('1.1.0'):
-        raise ImportError
 except ImportError:
-    raise AnsibleError('This script requires python-requests 1.1 as a minimum version')
+    raise AnsibleError('This script requires python-requests')
 
 
 class InventoryModule(BaseInventoryPlugin, Constructable):

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,4 +1,1 @@
 roles/insights_client/files/insights.fact shebang
-plugins/inventory/insights.py import-2.7 # needs 'requests'
-plugins/inventory/insights.py import-3.6 # needs 'requests'
-plugins/inventory/insights.py import-3.9 # needs 'requests'

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,3 +1,1 @@
 roles/insights_client/files/insights.fact shebang
-plugins/inventory/insights.py import-3.8 # needs 'requests'
-plugins/inventory/insights.py import-3.10 # needs 'requests'

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,4 +1,2 @@
 roles/insights_client/files/insights.fact shebang
-plugins/inventory/insights.py import-3.8 # needs 'requests'
-plugins/inventory/insights.py import-3.10 # needs 'requests'
 plugins/inventory/insights.py validate-modules:missing-gplv3-license # the plugin is licensed as Apache 2.0

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,4 +1,2 @@
 roles/insights_client/files/insights.fact shebang
-plugins/inventory/insights.py import-3.9 # needs 'requests'
-plugins/inventory/insights.py import-3.11 # needs 'requests'
 plugins/inventory/insights.py validate-modules:missing-gplv3-license # the plugin is licensed as Apache 2.0

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,4 +1,2 @@
 roles/insights_client/files/insights.fact shebang
-plugins/inventory/insights.py import-3.9 # needs 'requests'
-plugins/inventory/insights.py import-3.11 # needs 'requests'
 plugins/inventory/insights.py validate-modules:missing-gplv3-license # the plugin is licensed as Apache 2.0


### PR DESCRIPTION
Do not assume that `requests` is available, as the importing error will
not be properly noticeable in most of the environments; this is also
checked by the sanity testing of Ansible [1].

Follow the recommended practice by storing the import error separately,
raising it as Ansible error when the plugin is used. This makes it
possible to drop all the ignores for this issue for the sanity test.

As related/needed change: drop the version check for `requests`: v1.1.0 is more than 10 years old, and even old distros have much higher versions than that. This also gets rid of `distutils`, so there will be less problems with Python 3.12+.

[1] https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/import.html