### PR TITLE
ci: restore the execution on push

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
Make sure that pushes to `master` actually trigger the `ansible-test` workflow; this was accidentally broken when limiting by using the more modern `main` instead.

Since renaming the branch to `main` might be possible in the future, add `master` without removing `main`.

Fixes commit dd2418a14538fd16f32a87ffbdcc1027677628d4