### PR TITLE
ci: checkout PR branch only for PRs

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -84,6 +84,7 @@ jobs:
 
           # Show branch information
           git -C ansible_collections/redhat/insights branch -vv
+        if: github.event_name == 'pull_request'
 
       - name: Get git version
         id: git-version


### PR DESCRIPTION
When running the job on push, the checkout done by `actions/checkout` does not need to be tweaked for `ansible-community/ansible-test-gh-action`.