### PR TITLE
ci: use own script for rendering a jinja2 template

### DIFF
--- a/.github/scripts/jinja2-replace
+++ b/.github/scripts/jinja2-replace
@@ -1,0 +1,15 @@
+import os
+import sys
+
+import jinja2
+
+
+env = jinja2.Environment()
+with open(sys.argv[1]) as f:
+    tmpl = env.from_string(f.read())
+context = {}
+for key, value in os.environ.items():
+    if key.startswith("JINJA_"):
+        context[key[6:]] = value
+with open(sys.argv[2], "w") as f:
+    print(tmpl.render(context), file=f)

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -93,16 +93,16 @@ jobs:
           echo "git_version=$version" >> $GITHUB_OUTPUT
 
       - name: Generate galaxy.yml
-        uses: cuchi/jinja2-action@v1.2.1
-        with:
-          template: ansible_collections/redhat/insights/galaxy.yml.j2
-          output_file: ansible_collections/redhat/insights/galaxy.yml
-          strict: true
-          variables: |
-            collection_name=insights
-            collection_namespace=${{ github.repository_owner }}
-            collection_repo=https://github.com/${{ github.repository }}
-            collection_version=${{ steps.git-version.outputs.git_version }}
+        run: |
+          set -euxo pipefail
+          sudo apt-get --no-install-recommends -y install python3 python3-jinja2
+          python3 .github/scripts/jinja2-replace galaxy.yml.j2 galaxy.yml
+        working-directory: ansible_collections/redhat/insights
+        env:
+          JINJA_collection_name: insights
+          JINJA_collection_namespace: ${{ github.repository_owner }}
+          JINJA_collection_repo: https://github.com/${{ github.repository }}
+          JINJA_collection_version: ${{ steps.git-version.outputs.git_version }}
 
       - name: Run sanity tests
         uses: ansible-community/ansible-test-gh-action@release/v1


### PR DESCRIPTION
It looks like the cuchi/jinja2-action action is currently broken [1]. Since all we need is to render a jinja2 template with string variables, then roll out a simple script Python using the "jinja2" module to do that.

The script adds to the render context all the environment variables starting with the prefix `JINJA_`, removing it.

The script does not have a ".py" extension on purpose, to avoid being picked by ansible-test.

[1] https://github.com/cuchi/jinja2-action/issues/17