### PR TITLE
Fix docs description format

### DIFF
--- a/docs/insights_config.md
+++ b/docs/insights_config.md
@@ -43,9 +43,7 @@ Supply values for various configuration options that you would like to use. On i
 </td>
 <td></td>
 <td></td>
-<td><ul>
-<li>Attempt to auto-configure the network connection with Satellite or RHSM. Default is True.</li>
-</ul>
+<td>Attempt to auto-configure the network connection with Satellite or RHSM. Default is True.
 </td>
 </tr>
 <tr>

--- a/docs/insights_register.md
+++ b/docs/insights_register.md
@@ -33,9 +33,7 @@ This module will check the current registration status, unregister if needed, an
 <b>Default:</b><br>
 present</td>
 <td></td>
-<td><ul>
-<li>Determines whether to register or unregister insights-client</li>
-</ul>
+<td>Determines whether to register or unregister insights-client
 </td>
 </tr>
 <tr>

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -32,7 +32,8 @@ insights - insights inventory source
 </ul>
 </td>
 <td></td>
-<td>the name of this plugin, it should always be set to 'redhat.insights.insights' for this plugin to recognize it as its own.</td>
+<td>The name of this plugin, it should always be set to 'redhat.insights.insights' for this plugin to recognize it as its own.
+</td>
 </tr>
 <tr>
 <td><b>user</b></br>
@@ -90,7 +91,7 @@ insights</td>
 <td><b>Default:</b><br>
 insights_</td>
 <td></td>
-<td>prefix to apply to host variables</td>
+<td>Prefix to apply to host variables</td>
 </tr>
 <tr>
 <td><b>get_patches</b></br>

--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -13,7 +13,8 @@ DOCUMENTATION = '''
         - constructed
     options:
       plugin:
-        description: the name of this plugin, it should always be set to 'redhat.insights.insights' for this plugin to recognize it as its own.
+        description: >
+          The name of this plugin, it should always be set to 'redhat.insights.insights' for this plugin to recognize it as its own.
         required: true
         choices: ['redhat.insights.insights']
       user:
@@ -43,7 +44,7 @@ DOCUMENTATION = '''
         default: insights
         type: str
       vars_prefix:
-        description: prefix to apply to host variables
+        description: Prefix to apply to host variables
         default: insights_
         type: str
       get_patches:

--- a/plugins/modules/insights_config.py
+++ b/plugins/modules/insights_config.py
@@ -25,8 +25,8 @@ options:
       in the insights configuration. To remove a password set this value to an empty string.
     required: false
   auto_config:
-    description:
-    - Attempt to auto-configure the network connection with Satellite or RHSM. Default is True.
+    description: >
+      Attempt to auto-configure the network connection with Satellite or RHSM. Default is True.
     required: false
   authmethod:
     description: >

--- a/plugins/modules/insights_register.py
+++ b/plugins/modules/insights_register.py
@@ -22,8 +22,8 @@ description: >
 
 options:
   state:
-    description:
-      - Determines whether to register or unregister insights-client
+    description: >
+      Determines whether to register or unregister insights-client
     choices: [ present, absent ]
     default: present
     type: str


### PR DESCRIPTION
Some description lack of uppercase. Staleness used default instead of choices.