### PR TITLE
chore: add/fix names of plays and tasks

### DIFF
--- a/docs/create_docs.yml
+++ b/docs/create_docs.yml
@@ -1,9 +1,11 @@
 ---
-- hosts: localhost
+- name: Generate documentations
+  hosts: localhost
   connection: local
   gather_facts: false
   tasks:
-    - template:
+    - name: Generate docs from docs.md.j2
+      template:
         src: ./templates/docs.md.j2
         dest: "{{ item.output }}"
       vars:

--- a/release.yml
+++ b/release.yml
@@ -1,5 +1,5 @@
 ---
-- name: release collection
+- name: Release collection
   hosts: localhost
   gather_facts: false
   connection: local
@@ -11,51 +11,51 @@
     api_key: undef
 
   tasks:
-    - name: update namespace and name
+    - name: Update namespace and name
       block:
-        - name: fix inventory plugin
+        - name: Fix inventory plugin
           replace:
             path: "{{ playbook_dir }}/plugins/inventory/insights.py"
             regexp: redhat.insights
             replace: "{{ collection_namespace }}.{{ collection_name }}"
 
-        - name: fix role test
+        - name: Fix role test
           replace:
             path: "{{ playbook_dir }}/roles/insights_client/tests/example-insights-client-playbook.yml"
             regexp: redhat.insights
             replace: "{{ collection_namespace }}.{{ collection_name }}"
 
-    - name: create galaxy.yml
+    - name: Create galaxy.yml
       template:
         src: "{{ playbook_dir }}/galaxy.yml.j2"
         dest: "{{ playbook_dir }}/galaxy.yml"
 
-    - name: build collection
+    - name: Build collection
       command:
         cmd: ansible-galaxy collection build
         chdir: "{{ playbook_dir }}"
         creates: "{{ playbook_dir }}/{{ collection_namespace }}-{{ collection_name }}-{{ collection_version }}.tar.gz"
       tags: build
 
-    - name: install collection
+    - name: Install collection
       command:
         cmd: "ansible-galaxy collection install {{ collection_namespace }}-{{ collection_name }}-{{ collection_version }}.tar.gz -p ~/.ansible/collections/"
         chdir: "{{ playbook_dir }}"
       tags: install
 
-    - name: publish collection
+    - name: Publish collection
       command:
         cmd: "ansible-galaxy collection publish --api-key={{ api_key }} {{ collection_namespace }}-{{ collection_name }}-{{ collection_version }}.tar.gz"
         chdir: "{{ playbook_dir }}"
       tags: publish
 
-    - name: git cleanup
+    - name: Git cleanup
       # noqa: command-instead-of-module the git module does not do 'clean'
       command:
         cmd: git reset --hard
       tags: cleanup
 
-    - name: remove galaxy.yml
+    - name: Remove galaxy.yml
       file:
         path: "{{ playbook_dir }}/galaxy.yml"
         state: absent

--- a/roles/compliance/tasks/install.yml
+++ b/roles/compliance/tasks/install.yml
@@ -1,5 +1,5 @@
 ---
-- name: install openscap packages
+- name: Install OpenSCAP packages
   yum:
     name:
       - openscap

--- a/roles/compliance/tasks/main.yml
+++ b/roles/compliance/tasks/main.yml
@@ -1,8 +1,11 @@
 ---
-- name: check for insights configuration
+- name: Check for Insights configuration
   assert:
     that: ansible_local.insights is defined
     fail_msg: Unable to find insights fact. Have you installed the insights client?
 
-- include_tasks: install.yml
-- include_tasks: run.yml
+- name: Include install tasks
+  include_tasks: install.yml
+
+- name: Include run tasks
+  include_tasks: run.yml

--- a/roles/compliance/tasks/run.yml
+++ b/roles/compliance/tasks/run.yml
@@ -1,3 +1,3 @@
 ---
-- name: run compliance scan
+- name: Run compliance scan
   command: insights-client --compliance

--- a/roles/compliance/tests/compliance.yml
+++ b/roles/compliance/tests/compliance.yml
@@ -1,6 +1,7 @@
 ---
-- hosts: all
+- name: Simple test of compliance role
+  hosts: all
   tasks:
-    - name: insights compliance
+    - name: Insights compliance
       import_role:
         name: redhat.insights.compliance

--- a/roles/compliance/tests/install-only.yml
+++ b/roles/compliance/tests/install-only.yml
@@ -1,7 +1,8 @@
 ---
-- hosts: all
+- name: Install-only test of compliance role
+  hosts: all
   tasks:
-    - name: install insights compliance
+    - name: Install Insights compliance
       import_role:
         name: redhat.insights.compliance
         tasks_from: install

--- a/roles/compliance/tests/run-only.yml
+++ b/roles/compliance/tests/run-only.yml
@@ -1,7 +1,8 @@
 ---
-- hosts: all
+- name: Run-only test of compliance role
+  hosts: all
   tasks:
-    - name: run insights compliance
+    - name: Run Insights compliance
       import_role:
         name: redhat.insights.compliance
         tasks_from: run

--- a/roles/insights_client/tasks/main.yml
+++ b/roles/insights_client/tasks/main.yml
@@ -56,7 +56,7 @@
     path: /etc/ansible/facts.d
   become: true
 
-- name: Install custom insights fact
+- name: Install custom Insights fact
   copy:
     src: insights.fact
     dest: /etc/ansible/facts.d

--- a/roles/insights_client/tests/example-insights-client-playbook.yml
+++ b/roles/insights_client/tests/example-insights-client-playbook.yml
@@ -1,7 +1,9 @@
 ---
-- hosts: all
+- name: Simple test of insights_client role
+  hosts: all
   collections:
     - redhatinsights.insights
   tasks:
-    - include_role:
+    - name: Include insights_client role
+      include_role:
         name: insights_client


### PR DESCRIPTION
Plays and tasks ought to be named by default, and ansible-lint warns about that too. Hence:
- add names to plays and tasks that did not have any
- fix the existing names so they start with an uppercase letter