### PR TITLE
Few cleanups after old Ansible/Python removal

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -38,13 +38,7 @@ jobs:
             python: '3.9'
           - ansible: '2.16'
             python: '3.11'
-    # Ansible-test on various stable branches does not yet work well with cgroups v2.
-    # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
-    # image for these stable branches. The list of branches where this is necessary will
-    # shrink over time, check out https://github.com/ansible-collections/news-for-maintainers/issues/28
-    # for the latest list.
-    runs-on: >-
-      ${{ (contains(fromJson('["2.9", "2.10", "2.11"]'), matrix.ansible) || contains(fromJson('["2.7", "3.5", "3.6"]'), matrix.python)) && 'ubuntu-20.04' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     steps:
 
       # ansible-test requires the collection to be in a directory in the form
@@ -93,7 +87,6 @@ jobs:
       - name: Run sanity tests
         uses: ansible-community/ansible-test-gh-action@release/v1
         with:
-          ansible-core-github-repository-slug: ${{ contains(fromJson('["2.9", "2.10", "2.11"]'), matrix.ansible) && 'felixfontein/ansible' || 'ansible/ansible' }}
           ansible-core-version: stable-${{ matrix.ansible }}
           collection-src-directory: ${{ github.workspace }}/ansible_collections/redhat/insights
           coverage: ${{ github.event_name == 'schedule' && 'always' || 'never' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ are purposely not mentioned here.
   fixed when noticed/reported
 
 ### Fixed
-- `inventory` plugin: fix the retrieval of tags when using Python 2
 - `insights_register` module: actually make use of the `display_name` option,
   which was ignored until now
 - `insights_register` module: make the `force_reregister` option work again:

--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -302,7 +302,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             systems_by_id_list_split = [systems_by_id_list[i:i + chunk_size] for i in range(0, len(systems_by_id_list), chunk_size)]
             for items in systems_by_id_list_split:
                 partial_system_tags = self.get_tags(items)
-                system_tags.update(partial_system_tags)
+                system_tags = {**system_tags, **partial_system_tags}
 
         for uuid in systems_by_id:
             host_name = systems_by_id[uuid]


### PR DESCRIPTION
- revert commit 9916d9adba85c89a53fd7f91112b906e587f4a51, no more needed since Python 2.7 is not supported
- simplify the `ansible-test` CI workflow