### PR TITLE
ci: simplify code/branch checkout

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,0 +1,19 @@
+---
+name: ansible-lint
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+jobs:
+  ansibe-lint:
+    name: Ansible Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Run ansible-lint
+        uses: ansible/ansible-lint@v6

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -47,24 +47,12 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           path: ansible_collections/redhat/insights
 
-      - name: Check out the branch
+      - name: Show git info
         run: |
-          # Create a branch for the current HEAD, which happens to be a merge commit
-          git -C ansible_collections/redhat/insights checkout -b 'pull-request-${{ github.event.pull_request.number }}'
-
-          # Name the target branch
-          git -C ansible_collections/redhat/insights branch '${{
-            github.event.pull_request.base.ref
-          }}' --track 'origin/${{
-            github.event.pull_request.base.ref
-          }}'
-
-          # Show branch information
           git -C ansible_collections/redhat/insights branch -vv
-        if: github.event_name == 'pull_request'
 
       - name: Get git version
         id: git-version


### PR DESCRIPTION
Adopt a similar approach to what the ansible-test-gh-action does, in case that change detection is not enabled (which is the case):
- use a fetch-depth of 1, rather than 0
- drop the manual branch creation