### PR TITLE
fix: set a bash shebang recognized by ansible-test

### DIFF
--- a/roles/insights_client/files/insights.fact
+++ b/roles/insights_client/files/insights.fact
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 #     Copyright 2018,2017 Red Hat, Inc
 #

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,2 +1,1 @@
-roles/insights_client/files/insights.fact shebang
 plugins/inventory/insights.py validate-modules:missing-gplv3-license # the plugin is licensed as Apache 2.0

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,2 +1,1 @@
-roles/insights_client/files/insights.fact shebang
 plugins/inventory/insights.py validate-modules:missing-gplv3-license # the plugin is licensed as Apache 2.0

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,2 +1,1 @@
-roles/insights_client/files/insights.fact shebang
 plugins/inventory/insights.py validate-modules:missing-gplv3-license # the plugin is licensed as Apache 2.0


### PR DESCRIPTION
Few years ago, the `#!/bin/bash` shebang for bash scripts stopped to be allowed by ansible-test in favour of `#!/usr/bin/env bash` [1].

Hence, switch the fact script to `#!/usr/bin/env bash`, which will behave in the same way. This makes it possible to drop the ignores for this failure.

[1] https://github.com/ansible/ansible/pull/50954