### PR TITLE
ansible-lint lint fixes #2

### DIFF
--- a/docs/create_docs.yml
+++ b/docs/create_docs.yml
@@ -8,6 +8,7 @@
       template:
         src: ./templates/docs.md.j2
         dest: "{{ item.output }}"
+        mode: "u=rw,go=r"
       vars:
         # yamllint disable rule:line-length
         docs: "{{ lookup('file', '../' + item.file) | regex_search(\"(?<=DOCUMENTATION\\s=\\s''')((.|\\n)*?)(?=''')\") | from_yaml }}"

--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -76,10 +76,10 @@ DOCUMENTATION = '''
 '''
 
 EXAMPLES = '''
-# basic example using environment vars for auth
+# Basic example using environment variables for authentication
 plugin: redhat.insights.insights
 
-# create groups for patching
+# Create groups for patching
 plugin: redhat.insights.insights
 get_patches: true
 groups:
@@ -89,7 +89,7 @@ groups:
   security_patch: insights_patching.rhsa_count > 0
   enhancement_patch: insights_patching.rhea_count > 0
 
-# filter host by tags and create groups from tags
+# Filter host by tags and create groups from tags
 plugin: redhat.insights.insights
 get_tags: true
 filter_tags:

--- a/plugins/modules/insights_config.py
+++ b/plugins/modules/insights_config.py
@@ -54,24 +54,28 @@ author:
 '''
 
 EXAMPLES = '''
-- name: Configure the insights client to register with username and password stored in Ansible Tower Custom Credential
+# Configure the insights client to register with RHSM and no display name;
+# the insights_config module is used without parameters: this is because
+# auto_config defaults to true, which in turn forces the client to try RHSM
+# (or Satellite)
+- name: Configure the insights client
+  insights_config:
+  become: true
+
+# Configure the insights client to register with RHSM and a display name
+- name: Configure the insights client
+  insights_config:
+    display_name: "{{ insights_display_name }}"
+  become: true
+
+# Configure the insights client to register with username and password stored
+# as environment variables in the Ansible controller
+- name: Configure the insights client
   insights_config:
     username: "{{ lookup('env', INSIGHTS_USER) }}"
     password: "{{ lookup('env', INSIGHTS_PASSWORD) }}"
     auto_config: "{{ auto_config }}"
     authmethod: "{{ authmethod }}"
     proxy: "{{ insights_proxy }}"
-  become: true
-
-- name: Configure the insights client to register with RHSM and no display name
-  insights_config:
-  become: true
-
-# Note: The above example calls the insights_config module with no parameters. This is because auto_config defaults to True
-# which in turn forces the client to try RHSM (or Satellite)
-
-- name: Configure the insights client to register with RHSM and a display name
-  insights_config:
-    display_name: "{{ insights_display_name }}"
   become: true
 '''

--- a/plugins/modules/insights_register.py
+++ b/plugins/modules/insights_register.py
@@ -55,31 +55,24 @@ author:
 '''
 
 EXAMPLES = '''
-# Normal Register
+# Normal registration
 - name: Register the insights client
   insights_register:
     state: present
+  become: true
 
-# Force a Reregister (for config changes, etc)
-- name: Register the insights client
+# Force a registration (for config changes, etc)
+- name: Re-register the insights client
   insights_register:
     state: present
     force_reregister: true
+  become: true
 
-# Unregister
+# Unregistration
 - name: Unregister the insights client
   insights_register:
     state: absent
-
-# Register an install of redhat-access-insights (this is not a 100% automated process)
-- name: Register redhat-access-insights
-  insights_register:
-    state: present
-    insights_name: 'redhat-access-insights'
-
-# Note: The above example for registering redhat-access-insights requires that the playbook be
-# changed to install redhat-access-insights and that redhat-access-insights is also passed into
-# the insights_config module and that the file paths be changed when using the file module
+  become: true
 '''
 
 RETURN = '''

--- a/release.yml
+++ b/release.yml
@@ -42,18 +42,21 @@
       command:
         cmd: "ansible-galaxy collection install {{ collection_namespace }}-{{ collection_name }}-{{ collection_version }}.tar.gz -p ~/.ansible/collections/"
         chdir: "{{ playbook_dir }}"
+      changed_when: true
       tags: install
 
     - name: Publish collection
       command:
         cmd: "ansible-galaxy collection publish --api-key={{ api_key }} {{ collection_namespace }}-{{ collection_name }}-{{ collection_version }}.tar.gz"
         chdir: "{{ playbook_dir }}"
+      changed_when: true
       tags: publish
 
     - name: Git cleanup
       # noqa: command-instead-of-module the git module does not do 'clean'
       command:
         cmd: git reset --hard
+      changed_when: true
       tags: cleanup
 
     - name: Remove galaxy.yml

--- a/release.yml
+++ b/release.yml
@@ -29,6 +29,7 @@
       template:
         src: "{{ playbook_dir }}/galaxy.yml.j2"
         dest: "{{ playbook_dir }}/galaxy.yml"
+        mode: "u=rw,go=r"
 
     - name: Build collection
       command:

--- a/roles/compliance/tasks/install.yml
+++ b/roles/compliance/tasks/install.yml
@@ -1,5 +1,7 @@
 ---
 - name: Install OpenSCAP packages
+  # noqa package-latest it needs to ensure that the latest available packages
+  #                     are installed
   yum:
     name:
       - openscap

--- a/roles/compliance/tasks/run.yml
+++ b/roles/compliance/tasks/run.yml
@@ -1,3 +1,4 @@
 ---
 - name: Run compliance scan
   command: insights-client --compliance
+  changed_when: true

--- a/roles/insights_client/handlers/main.yml
+++ b/roles/insights_client/handlers/main.yml
@@ -1,4 +1,5 @@
 ---
 - name: Run insights-client
   command: insights-client
+  changed_when: true
   become: true


### PR DESCRIPTION
This is a second round of fixes for `ansible-lint`; this includes:
- setting permissions for `template` outputs
- adding `changed_when` to `command` modules that do not create files
- a `noqa` exclude for a known/wanted situation
- improvements to the examples of the plugins

There should be no behaviour changes.

The documentation will be regenerated later on, before the next tagging.