### PR TITLE
FQCN fixes

### DIFF
--- a/docs/create_docs.yml
+++ b/docs/create_docs.yml
@@ -5,7 +5,7 @@
   gather_facts: false
   tasks:
     - name: Generate docs from docs.md.j2
-      template:
+      ansible.builtin.template:
         src: ./templates/docs.md.j2
         dest: "{{ item.output }}"
         mode: "u=rw,go=r"

--- a/release.yml
+++ b/release.yml
@@ -14,39 +14,39 @@
     - name: Update namespace and name
       block:
         - name: Fix inventory plugin
-          replace:
+          ansible.builtin.replace:
             path: "{{ playbook_dir }}/plugins/inventory/insights.py"
             regexp: redhat.insights
             replace: "{{ collection_namespace }}.{{ collection_name }}"
 
         - name: Fix role test
-          replace:
+          ansible.builtin.replace:
             path: "{{ playbook_dir }}/roles/insights_client/tests/example-insights-client-playbook.yml"
             regexp: redhat.insights
             replace: "{{ collection_namespace }}.{{ collection_name }}"
 
     - name: Create galaxy.yml
-      template:
+      ansible.builtin.template:
         src: "{{ playbook_dir }}/galaxy.yml.j2"
         dest: "{{ playbook_dir }}/galaxy.yml"
         mode: "u=rw,go=r"
 
     - name: Build collection
-      command:
+      ansible.builtin.command:
         cmd: ansible-galaxy collection build
         chdir: "{{ playbook_dir }}"
         creates: "{{ playbook_dir }}/{{ collection_namespace }}-{{ collection_name }}-{{ collection_version }}.tar.gz"
       tags: build
 
     - name: Install collection
-      command:
+      ansible.builtin.command:
         cmd: "ansible-galaxy collection install {{ collection_namespace }}-{{ collection_name }}-{{ collection_version }}.tar.gz -p ~/.ansible/collections/"
         chdir: "{{ playbook_dir }}"
       changed_when: true
       tags: install
 
     - name: Publish collection
-      command:
+      ansible.builtin.command:
         cmd: "ansible-galaxy collection publish --api-key={{ api_key }} {{ collection_namespace }}-{{ collection_name }}-{{ collection_version }}.tar.gz"
         chdir: "{{ playbook_dir }}"
       changed_when: true
@@ -54,13 +54,13 @@
 
     - name: Git cleanup
       # noqa: command-instead-of-module the git module does not do 'clean'
-      command:
+      ansible.builtin.command:
         cmd: git reset --hard
       changed_when: true
       tags: cleanup
 
     - name: Remove galaxy.yml
-      file:
+      ansible.builtin.file:
         path: "{{ playbook_dir }}/galaxy.yml"
         state: absent
       tags: cleanup

--- a/roles/compliance/tasks/install.yml
+++ b/roles/compliance/tasks/install.yml
@@ -2,7 +2,7 @@
 - name: Install OpenSCAP packages
   # noqa package-latest it needs to ensure that the latest available packages
   #                     are installed
-  yum:
+  ansible.builtin.yum:
     name:
       - openscap
       - scap-security-guide

--- a/roles/compliance/tasks/main.yml
+++ b/roles/compliance/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 - name: Check for Insights configuration
-  assert:
+  ansible.builtin.assert:
     that: ansible_local.insights is defined
     fail_msg: Unable to find insights fact. Have you installed the insights client?
 
 - name: Include install tasks
-  include_tasks: install.yml
+  ansible.builtin.include_tasks: install.yml
 
 - name: Include run tasks
-  include_tasks: run.yml
+  ansible.builtin.include_tasks: run.yml

--- a/roles/compliance/tasks/run.yml
+++ b/roles/compliance/tasks/run.yml
@@ -1,4 +1,4 @@
 ---
 - name: Run compliance scan
-  command: insights-client --compliance
+  ansible.builtin.command: insights-client --compliance
   changed_when: true

--- a/roles/compliance/tests/compliance.yml
+++ b/roles/compliance/tests/compliance.yml
@@ -3,5 +3,5 @@
   hosts: all
   tasks:
     - name: Insights compliance
-      import_role:
+      ansible.builtin.import_role:
         name: redhat.insights.compliance

--- a/roles/compliance/tests/install-only.yml
+++ b/roles/compliance/tests/install-only.yml
@@ -3,6 +3,6 @@
   hosts: all
   tasks:
     - name: Install Insights compliance
-      import_role:
+      ansible.builtin.import_role:
         name: redhat.insights.compliance
         tasks_from: install

--- a/roles/compliance/tests/run-only.yml
+++ b/roles/compliance/tests/run-only.yml
@@ -3,6 +3,6 @@
   hosts: all
   tasks:
     - name: Run Insights compliance
-      import_role:
+      ansible.builtin.import_role:
         name: redhat.insights.compliance
         tasks_from: run

--- a/roles/insights_client/handlers/main.yml
+++ b/roles/insights_client/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
 - name: Run insights-client
-  command: insights-client
+  ansible.builtin.command: insights-client
   changed_when: true
   become: true

--- a/roles/insights_client/tasks/main.yml
+++ b/roles/insights_client/tasks/main.yml
@@ -15,7 +15,7 @@
 #     limitations under the License.
 #
 - name: Install 'insights-client'
-  yum:
+  ansible.builtin.yum:
     name: insights-client
   become: true
   notify: Run insights-client
@@ -37,27 +37,27 @@
   become: true
 
 - name: Change permissions of Insights Config directory so that Insights System ID can be read
-  file:
+  ansible.builtin.file:
     path: /etc/insights-client
     mode: og=rx
   become: true
 
 - name: Change permissions of machine_id file so that Insights System ID can be read
-  file:
+  ansible.builtin.file:
     path: /etc/insights-client/machine-id
     mode: og=r
   become: true
   notify: Run insights-client
 
 - name: Create directory for ansible custom facts
-  file:
+  ansible.builtin.file:
     state: directory
     recurse: true
     path: /etc/ansible/facts.d
   become: true
 
 - name: Install custom Insights fact
-  copy:
+  ansible.builtin.copy:
     src: insights.fact
     dest: /etc/ansible/facts.d
     mode: a+x
@@ -65,7 +65,7 @@
   notify: Run insights-client
 
 - name: Deploy Custom Tags
-  copy:
+  ansible.builtin.copy:
     dest: /etc/insights-client/tags.yaml
     content: "{{ insights_tags | to_nice_yaml }}"
     mode: og=r
@@ -74,7 +74,7 @@
   notify: Run insights-client
 
 - name: Remove Tags
-  file:
+  ansible.builtin.file:
     path: /etc/insights-client/tags.yaml
     state: absent
   become: true

--- a/roles/insights_client/tests/example-insights-client-playbook.yml
+++ b/roles/insights_client/tests/example-insights-client-playbook.yml
@@ -1,9 +1,7 @@
 ---
 - name: Simple test of insights_client role
   hosts: all
-  collections:
-    - redhatinsights.insights
   tasks:
     - name: Include insights_client role
       ansible.builtin.include_role:
-        name: insights_client
+        name: redhatinsights.insights.insights_client

--- a/roles/insights_client/tests/example-insights-client-playbook.yml
+++ b/roles/insights_client/tests/example-insights-client-playbook.yml
@@ -5,5 +5,5 @@
     - redhatinsights.insights
   tasks:
     - name: Include insights_client role
-      include_role:
+      ansible.builtin.include_role:
         name: insights_client


### PR DESCRIPTION
Invoke the builtin modules (i.e. those shipped in ansible-core) using their FQCN, as recommended when using newer Ansible version with no need to support very old ones.

Do the same also for a local example.