### PR TITLE
Fix replacing the collection name on release

### DIFF
--- a/release.yml
+++ b/release.yml
@@ -19,8 +19,13 @@
             regexp: redhat.insights
             replace: "{{ collection_namespace }}.{{ collection_name }}"
           loop:
+            - docs/inventory.md
             - plugins/inventory/insights.py
+            - roles/compliance/tests/compliance.yml
+            - roles/compliance/tests/install-only.yml
+            - roles/compliance/tests/run-only.yml
             - roles/insights_client/tests/example-insights-client-playbook.yml
+            - tests/inventory/insights.yml
 
     - name: Create galaxy.yml
       ansible.builtin.template:

--- a/release.yml
+++ b/release.yml
@@ -13,17 +13,14 @@
   tasks:
     - name: Update namespace and name
       block:
-        - name: Fix inventory plugin
+        - name: Fix namespace and name references in files
           ansible.builtin.replace:
-            path: "{{ playbook_dir }}/plugins/inventory/insights.py"
+            path: "{{ playbook_dir }}/{{ item }}"
             regexp: redhat.insights
             replace: "{{ collection_namespace }}.{{ collection_name }}"
-
-        - name: Fix role test
-          ansible.builtin.replace:
-            path: "{{ playbook_dir }}/roles/insights_client/tests/example-insights-client-playbook.yml"
-            regexp: redhat.insights
-            replace: "{{ collection_namespace }}.{{ collection_name }}"
+          loop:
+            - plugins/inventory/insights.py
+            - roles/insights_client/tests/example-insights-client-playbook.yml
 
     - name: Create galaxy.yml
       ansible.builtin.template:

--- a/roles/insights_client/tests/example-insights-client-playbook.yml
+++ b/roles/insights_client/tests/example-insights-client-playbook.yml
@@ -4,4 +4,4 @@
   tasks:
     - name: Include insights_client role
       ansible.builtin.include_role:
-        name: redhatinsights.insights.insights_client
+        name: redhat.insights.insights_client


### PR DESCRIPTION
The release playbook has a logic to replace the collection name depending on the parameters (the namespace and the name); this logic had few issues:
- copy&paste approach for the places where it was set
- a wrong collection name in one place, so it was not set as needed
- more places in which the collection name needs to be set set

This fixes the aforementioned issues. The list of places where to set the collection name is still a fixed list, however it should be easier to maintain now, and it rarely changes.