### PR TITLE
inventory: switch to v3 of the patch service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ that have any kind of impact on users, such as new & removed features, behaviour
 changes, and bug fixes. Internal changes such as for CI, style/lint, and so on
 are purposely not mentioned here.
 
+## [unreleased]
+### Changed
+- `inventory` plugin: use the v3 API of the "patch" endpoint; the only changes
+  in the results are some different properties in the `<vars_prefix>patching`
+  variable set for each host
+
 ## [1.1.0]
 ### Changed
 - There is no more a maximum supported version of Ansible for the collection,

--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -118,7 +118,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
     def get_patches(self, stale, get_system_advisories, get_system_packages, filter_tags):
         def get_system_patching_info(system_id, info):
-            query = "api/patch/v1/export/systems"
+            query = "api/patch/v3/export/systems"
             url = "%s/%s/%s/%s" % (self.server, query, system_id, info)
             response = self.session.get(url, auth=self.auth, headers=self.headers)
             if response.status_code != 200:
@@ -140,7 +140,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 result['attributes'][patching_info] = patching_info_result
             return results
 
-        query = "api/patch/v1/systems?filter[stale]=%s" % stale
+        query = "api/patch/v3/systems?filter[stale]=%s" % stale
         url = format_url(self.server, query, filter_tags)
         results = []
         while url:


### PR DESCRIPTION
Luckly the API we use is compatible, so there are no changes required, other than the version bump.

The only changes in the results are some different properties in the `<vars_prefix>patching` variable set for each host.