### PR TITLE
ci: drop workaround for ansible-lint action bug

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -21,14 +21,6 @@ jobs:
         with:
           path: ansible_collections/redhat/insights
 
-      - name: Workaround ansible-lint action bug
-        run: |
-          # create a symlink to the .git directory of the checkout
-          # in the local directory: the current ansible-lint action (v6.22.0)
-          # does not use its "working_directory" for all its steps;
-          # https://github.com/ansible/ansible-lint/pull/3905
-          ln -s ansible_collections/redhat/insights/.git .
-
       - name: Set Ansible environment variables (#1)
         run: |
           echo "ANSIBLE_COLLECTIONS_PATH=$PWD" >> "$GITHUB_ENV"


### PR DESCRIPTION
There was a bug [1] in the ansible-lint action that made its "working_directory" parameter not working as expected. This was fixed in v6.22.1 [2].

Since we use the "v6" tag, which points to the latest version of ansible-lint 6.x, the fixed action should be used already. Hence, drop the workaround step.

[1] https://github.com/ansible/ansible-lint/pull/3905
[2] https://github.com/ansible/ansible-lint/releases/tag/v6.22.1