### PR TITLE
ci: bump Python for release to 3.12

### DIFF
--- a/.github/workflows/galaxy-release.yml
+++ b/.github/workflows/galaxy-release.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.8
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Install ansible-base
         run: pip install ansible


### PR DESCRIPTION
Bump the Python installed when uploading a new release to Galaxy to 3.12:
- the current Python 3.8 was supported last by ansible-core 2.13, which is EOL now
- Python 3.12 should be supported until ansible-core 2.21, so plenty of time

Also drop the mention of the Python version from the task name, as it is not of much use.