### PR TITLE
Fix bug preventing registration from working as expected

### DIFF
--- a/plugins/modules/insights_register.py
+++ b/plugins/modules/insights_register.py
@@ -137,7 +137,7 @@ def run_module():
                 module.exit_json(**result)
         if display_name:
             register_args.extend(['--display-name', display_name])
-        register_args.extend('--register')
+        register_args.extend(['--register'])
         subprocess.call(register_args)
         result['changed'] = True
         if force_reregister:


### PR DESCRIPTION
## Synopsis

Hello,

I seem to have encountered and hopefully solved a small but impactful bug. The insights_register module registration wasn't able to complete registration at all on my clean RHEL 9.3 system on my first shot trying it. This seems to be because the '--register' parameter is passed as a string to the .extend function of the `register_args` list on line 140 rather than as a list:
https://github.com/RedHatInsights/ansible-collections-insights/blob/22dfe8e8cd69f0ab6378732678a3e9b1db6f8866/plugins/modules/insights_register.py#L140

This results in the unexpected behavior of passing each character in the string as an individual argument, spacing them out on the command line in the background. Unfortunately this fails silently, producing messages as though it worked from the ansible perspective, however does not manage to make the change. 

The fix I'm proposing is to add square brackets to pass the parameter as a list instead of a string, just like how other argument parameters in the module are being passed. A detailed demonstration of the issue is below. This small change enabled the module to function as expected in my experience. My python and ansible module development experience is somewhat limited, so someone who knows what they're doing should probably affirm and/or improve my suggestion before integrating. 

## Version info

- module version: redhatinsights.insights 1.2.0 
- OS: RHEL 9.3
- ansible-core: 2.14.9
- python: 3.9.18

## Demonstration

### Starting point: an unregistered system
```
[localadmin@mgmt-new ~]$ sudo insights-client --status
System is NOT registered locally via .registered file. Unregistered at 2023-12-22T14:42:25.752780
Insights API says this machine is NOT registered.
System unregistered locally via .unregistered file
```

### Using simple playbook:
```
---
- name: Red Hat - Register with Insights
  hosts: all
  become: yes
  tasks:
    - redhatinsights.insights.insights_register:
        state: present
...
```

### The module produces abbreviated verbose output:
```
changed: [mgmt-new] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "display_name": null,
            "force_reregister": false,
            "insights_name": "insights-client",
            "state": "present"
        }
    },
    "message": "insights-client has been registered",
    "original_message": "Attempting to register insights-client"
}
```
However, the system remains **unregistered** as demonstrated by `insights-client --status`.

### Digging deeper
With some modifications to show the output from the `insights-client --register` command executed by the module, you can see evidence of the spaced out parameter (scroll horizontally to the very end):

```
fatal: [mgmt-new]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "display_name": null,
            "force_reregister": false,
            "insights_name": "insights-client",
            "state": "present"
        }
    },
    "msg": "Failed to register, error: usage: insights-client [-h] [--ansible-host ANSIBLE_HOST] [--checkin]\n                       [--collector APP] [--manifest MANIFEST]\n                       [--build-packagecache] [--compliance] [--conf CONF]\n                       [--disable-schedule] [--display-name DISPLAY_NAME]\n                       [--enable-schedule] [--group GROUP] [--keep-archive]\n                       [--list-specs] [--logging-file LOGGING_FILE]\n                       [--net-debug] [--no-upload] [--offline]\n                       [--output-dir OUTPUT_DIR] [--output-file OUTPUT_FILE]\n                       [--quiet] [--register] [--force-reregister]\n                       [--retry RETRIES] [--show-results] [--silent]\n                       [--status] [--support] [--test-connection]\n                       [--unregister] [--validate] [--verbose] [--version]\n                       [--payload PAYLOAD] [--content-type CONTENT_TYPE]\n                       [--diagnosis [DIAGNOSIS]]\ninsights-client: error: unrecognized arguments: - - r e g i s t e r\n"
}
```