### PR TITLE
Adding missing configuration options to both the action plugin insights_config and the role insights_client

### DIFF
--- a/plugins/action/insights_config.py
+++ b/plugins/action/insights_config.py
@@ -18,7 +18,18 @@ class ActionModule(ActionBase):
             auto_config=self._task.args.get('auto_config', None),
             authmethod=self._task.args.get('authmethod', None),
             display_name=self._task.args.get('display_name', None),
-            proxy=self._task.args.get('proxy', None)
+            proxy=self._task.args.get('proxy', None),
+            base_url=self._task.args.get('base_url', None),
+            auto_update=self._task.args.get('auto_update', None),
+            obfuscate=self._task.args.get('obfuscate', None),
+            obfuscate_hostname=self._task.args.get('obfuscate_hostname', None),
+            ansible_host=self._task.args.get('ansible_host', None),
+            cmd_timeout=self._task.args.get('cmd_timeout', None),
+            http_timeout=self._task.args.get('http_timeout', None),
+            core_collect=self._task.args.get('core_collect', None),
+            redaction_file=self._task.args.get('redaction_file', None),
+            content_redaction_file=self._task.args.get('content_redaction_file', None),
+            tags_file=self._task.args.get('tags_file', None)
         )
 
         for k, v in config_vars.items():

--- a/plugins/modules/insights_config.py
+++ b/plugins/modules/insights_config.py
@@ -48,7 +48,7 @@ options:
       This set an optional proxy for the insights client to connect through if the client
       is behind a firewall or requires a proxy. Default is unspecified (none).
     required: false
- loglevel:
+  loglevel:
     description: >
       Log level the Insights client should use. Default is unspecified (none), which means
       the configuration file of the Insights client will not be touched and therefore uses
@@ -152,28 +152,6 @@ EXAMPLES = '''
     proxy: "{{ insights_proxy }}"
   become: true
 
-- name: Configure the Insights client with all available options when passing variables as a role variables
-  insights_config:
-    username: "{{ redhat_portal_username }}"
-    password: "{{ redhat_portal_password }}"
-    auto_config: "{{ auto_config }}"
-    authmethod: "{{ authmethod }}"
-    proxy: "{{ insights_proxy }}"
-    loglevel: "{{ insights_loglevel }}"
-    auto_config: "{{ insights_auto_config }}"
-    base_url: "{{ insights_base_url }}"
-    auto_update: "{{ insights_auto_update }}"
-    obfuscate: "{{ insights_obfuscate }}"
-    obfuscate_hostname: "{{ insights_obfuscate_hostname }}"
-    ansible_host: "{{ insights_ansible_host }}"
-    cmd_timeout: "{{ insights_cmd_timeout }}"
-    http_timeout: "{{ insights_http_timeout }}"
-    core_collect: "{{ insights_core_collect }}"
-    redaction_file: "{{ insights_redaction_file }}"
-    content_redaction_file: "{{ insights_content_redaction_file }}"
-    tags_file: "{{ insights_tags_file }}"
-  become: true
-
 - name: Configure the Insights client with all available options
   insights_config:
     username: John
@@ -181,7 +159,6 @@ EXAMPLES = '''
     auto_config: true
     authmethod: CERT
     loglevel: DEBUG
-    auto_config: true
     base_url: cert-api.access.redhat.com:443/r/insights
     auto_update: true
     obfuscate: true
@@ -190,4 +167,5 @@ EXAMPLES = '''
     cmd_timeout: 120
     http_timeout: 120
     core_collect: true
+  become: true
 '''

--- a/plugins/modules/insights_config.py
+++ b/plugins/modules/insights_config.py
@@ -48,6 +48,79 @@ options:
       This set an optional proxy for the insights client to connect through if the client
       is behind a firewall or requires a proxy. Default is unspecified (none).
     required: false
+ loglevel:
+    description: >
+      Log level the Insights client should use. Default is unspecified (none), which means
+      the configuration file of the Insights client will not be touched and therefore uses
+      the default configured by the Insights client itself.
+    required: false
+  base_url:
+    description: >
+      Base URL for the Insights API. Default is unspecified (none), which means the configuration
+      file of the Insights client will not be touched and therefore uses the default configured
+      by the Insights client itself.
+    required: false
+  auto_update:
+    description: >
+      Automatically update the dynamic configuration. Default is unspecified (none),
+      which means the configuration file of the Insights client will not be touched and
+      therefore uses the default configured by the Insights client itself.
+    required: false
+  obfuscate:
+    description: >
+      Obfuscate IP addresses. Default is unspecified (none), which means the
+      configuration file of the Insights client will not be touched and therefore uses the
+      default configured by the Insights client itself.
+    required: false
+  obfuscate_hostname:
+    description: >
+      Obfuscate hostname. Requires obfuscate=True. Default is unspecified (none),
+      which means the configuration file of the Insights client will not be touched and therefore
+      uses the default configured by the Insights client itself.
+    required: false
+  ansible_host:
+    description: >
+      Ansible hostname for this system as reported to the Insights API. Default is
+      unspecified (none), which means the configuration file of the Insights client will not be
+      touched and therefore uses the default configured by the Insights client itself.
+    required: false
+  cmd_timeout:
+    description: >
+      Timeout for commands run during collection, in seconds. Default is unspecified (none),
+      which means the configuration file of the Insights client will not be
+      touched and therefore uses the default configured by the Insights client itself.
+    required: false
+  http_timeout:
+    description: >
+      Timeout for HTTP calls, in seconds. Default is unspecified (none),
+      which means the configuration file of the Insights client will not be
+      touched and therefore uses the default configured by the Insights client itself.
+    required: false
+  core_collect:
+    description: >
+      Use insights-core as the collection source. Included for compatibility only.
+      Modify only as directed. Default is unspecified (none), which means the configuration
+      file of the Insights client will not be touched and therefore uses the default
+      configured by the Insights client itself.
+    required: false
+  redaction_file:
+    description: >
+     Location of the redaction file for commands, files, and components. Default is
+      unspecified (none), which means the configuration file of the Insights client will not
+      be touched and therefore uses the default configured by the Insights client itself.
+    required: false
+  content_redaction_file:
+    description: >
+      Location of the redaction file for patterns and keywords. Default is
+      unspecified (none), which means the configuration file of the Insights client will not
+      be touched and therefore uses the default configured by the Insights client itself.
+    required: false
+  tags_file:
+    description: >
+      Location of the tags file for this system. Default is unspecified (none), which
+      means the configuration file of the Insights client will not be touched and therefore
+      uses the default configured by the Insights client itself.
+    required: false
 
 author:
     - Jason Stephens (@Jason-RH)
@@ -78,4 +151,43 @@ EXAMPLES = '''
     authmethod: "{{ authmethod }}"
     proxy: "{{ insights_proxy }}"
   become: true
+
+- name: Configure the Insights client with all available options when passing variables as a role variables
+  insights_config:
+    username: "{{ redhat_portal_username }}"
+    password: "{{ redhat_portal_password }}"
+    auto_config: "{{ auto_config }}"
+    authmethod: "{{ authmethod }}"
+    proxy: "{{ insights_proxy }}"
+    loglevel: "{{ insights_loglevel }}"
+    auto_config: "{{ insights_auto_config }}"
+    base_url: "{{ insights_base_url }}"
+    auto_update: "{{ insights_auto_update }}"
+    obfuscate: "{{ insights_obfuscate }}"
+    obfuscate_hostname: "{{ insights_obfuscate_hostname }}"
+    ansible_host: "{{ insights_ansible_host }}"
+    cmd_timeout: "{{ insights_cmd_timeout }}"
+    http_timeout: "{{ insights_http_timeout }}"
+    core_collect: "{{ insights_core_collect }}"
+    redaction_file: "{{ insights_redaction_file }}"
+    content_redaction_file: "{{ insights_content_redaction_file }}"
+    tags_file: "{{ insights_tags_file }}"
+  become: true
+
+- name: Configure the Insights client with all available options
+  insights_config:
+    username: John
+    password: secret_P4ssW0rd.
+    auto_config: true
+    authmethod: CERT
+    loglevel: DEBUG
+    auto_config: true
+    base_url: cert-api.access.redhat.com:443/r/insights
+    auto_update: true
+    obfuscate: true
+    obfuscate_hostname: true
+    ansible_host: my_host.example.com
+    cmd_timeout: 120
+    http_timeout: 120
+    core_collect: true
 '''

--- a/roles/insights_client/README.md
+++ b/roles/insights_client/README.md
@@ -88,6 +88,66 @@ See the section 'Example Playbook' for information on various ways to use these 
         state: nc
         city: durham
     ```
+* insights_loglevel: (optional)
+    Log level the Insights client should use. Default is unspecified (none), which means
+    the configuration file of the Insights client will not be touched and therefore uses
+    the default configured by the Insights client itself.
+
+* insights_base_url: (optional)
+    Base URL for the Insights API. Default is unspecified (none), which means the configuration
+    file of the Insights client will not be touched and therefore uses the default configured
+    by the Insights client itself.
+
+* insights_auto_update: (optional)
+    Automatically update the dynamic configuration. Default is unspecified (none),
+    which means the configuration file of the Insights client will not be touched and
+    therefore uses the default configured by the Insights client itself.
+
+* insights_obfuscate: (optional)
+    Obfuscate IP addresses. Default is unspecified (none), which means the
+    configuration file of the Insights client will not be touched and therefore uses the
+    default configured by the Insights client itself.
+
+* insights_obfuscate_hostname: (optional)
+    Obfuscate hostname. Requires obfuscate=True. Default is unspecified (none),
+    which means the configuration file of the Insights client will not be touched and therefore
+    uses the default configured by the Insights client itself.
+
+* insights_ansible_host: (optional)
+    Ansible hostname for this system as reported to the Insights API. Default is
+    unspecified (none), which means the configuration file of the Insights client will not be
+    touched and therefore uses the default configured by the Insights client itself.
+
+* insights_cmd_timeout: (optional)
+    Timeout for commands run during collection, in seconds. Default is unspecified (none),
+    which means the configuration file of the Insights client will not be
+    touched and therefore uses the default configured by the Insights client itself.
+
+* insights_http_timeout: (optional)
+    Timeout for HTTP calls, in seconds. Default is unspecified (none),
+    which means the configuration file of the Insights client will not be
+    touched and therefore uses the default configured by the Insights client itself.
+
+* insights_core_collect: (optional)
+    Use insights-core as the collection source. Included for compatibility only.
+    Modify only as directed. Default is unspecified (none), which means the configuration
+    file of the Insights client will not be touched and therefore uses the default
+    configured by the Insights client itself.
+
+* insights_redaction_file: (optional)
+    Location of the redaction file for commands, files, and components. Default is
+    unspecified (none), which means the configuration file of the Insights client will not
+    be touched and therefore uses the default configured by the Insights client itself.
+
+* insights_content_redaction_file: (optional)
+    Location of the redaction file for patterns and keywords. Default is
+    unspecified (none), which means the configuration file of the Insights client will not
+    be touched and therefore uses the default configured by the Insights client itself.
+
+* insights_tags_file: (optional)
+    Location of the tags file for this system. Default is unspecified (none), which
+    means the configuration file of the Insights client will not be touched and therefore
+    uses the default configured by the Insights client itself.
 
 * ansible_python_interpreter: (see Requirements above to determine if this is needed)
 

--- a/roles/insights_client/tasks/main.yml
+++ b/roles/insights_client/tasks/main.yml
@@ -28,6 +28,17 @@
     authmethod: "{{ authmethod | default(omit) }}"
     display_name: "{{ insights_display_name | default(omit) }}"
     proxy: "{{ insights_proxy | default(omit) }}"
+    base_url: "{{ insights_base_url | default(omit) }}"
+    auto_update: "{{ insights_auto_update | default(omit) }}"
+    obfuscate: "{{ insights_obfuscate | default(omit) }}"
+    obfuscate_hostname: "{{ insights_obfuscate_hostname | default(omit) }}"
+    ansible_host: "{{ insights_ansible_host | default(omit) }}"
+    cmd_timeout: "{{ insights_cmd_timeout | default(omit) }}"
+    http_timeout: "{{ insights_http_timeout | default(omit) }}"
+    core_collect: "{{ insights_core_collect | default(omit) }}"
+    redaction_file: "{{ insights_redaction_file | default(omit) }}"
+    content_redaction_file: "{{ insights_content_redaction_file | default(omit) }}"
+    tags_file: "{{ insights_tags_file | default(omit) }}"
   become: true
   notify: Run insights-client
 
@@ -64,9 +75,67 @@
   become: true
   notify: Run insights-client
 
+- name: Slurp Insights config
+  ansible.builtin.slurp:
+    src: /etc/insights-client/insights-client.conf
+  register: _insights_conf
+
+- name: Set default tags_file path
+  ansible.builtin.set_fact:
+    _tags_file_path: /etc/insights-client/tags.yaml
+
+- name: 'Handle tags_file present in the configuration file'
+  when: >
+    _insights_conf.content | b64decode |
+    regex_findall('^(?<!#)\\s?tags_file\\s?=\\s?.+$', multiline=true)
+  block:
+
+    - name: Ensure only one configuration tags_file is present in the Insights configuration
+      ansible.builtin.assert:
+        that:
+          - _insights_conf.content | b64decode |
+            regex_findall('^(?<!#)\\s?tags_file\\s?=\\s?.+$', multiline=true) | length == 1
+        success_msg: Only one tags_file configuration entry was found.
+        fail_msg: >
+          More than one tags_file configuration entry was found. Please check the Insights
+          configuration on the host and correct this at /etc/insights-client/insights-client.conf
+
+    - name: Ensure tags_file path does not contain equal signs
+      ansible.builtin.assert:
+        that:
+          - _insights_conf.content |
+            b64decode |
+            regex_findall('^(?<!#)\\s?tags_file\\s?=\\s?.+$', multiline=true) |
+            first |
+            regex_findall('=') |
+            length == 1
+        success_msg: Path does not contain any equal signs.
+        fail_msg: >
+          Path contains one or more equal signs. Please check the option tags_file in the
+          Insights client configuration at /etc/insights-client/insights-client.conf and
+          correct this.
+
+    - name: Override tags_file path with the path retrieved from the configuration file
+      ansible.builtin.set_fact:
+        _tags_file_path: >-
+          {{
+            _insights_conf.content |
+            b64decode |
+            regex_findall('^(?<!#)\s?tags_file\s?=\s?.+$', multiline=true) |
+            first |
+            split('=') |
+            last |
+            trim
+          }}
+
+- name: Debug Insights tags_file path set
+  ansible.builtin.debug:
+    var: _tags_file_path
+    verbosity: 1
+
 - name: Deploy Custom Tags
   ansible.builtin.copy:
-    dest: /etc/insights-client/tags.yaml
+    dest: "{{ _tags_file_path }}"
     content: "{{ insights_tags | to_nice_yaml }}"
     mode: og=r
   become: true
@@ -75,7 +144,7 @@
 
 - name: Remove Tags
   ansible.builtin.file:
-    path: /etc/insights-client/tags.yaml
+    path: "{{ _tags_file_path }}"
     state: absent
   become: true
   when: insights_tags is not defined


### PR DESCRIPTION
First time contribution to this collection, so please go easy on me! 🙂 

I have added all missing options which are available in `/etc/insights-client/insights-client.conf`.

If there are any other options I missed, please let me know, I am happy to implement them! 😊

Since `tags_file` is one of those configuration options, I needed to modify the deployment of custom tags of the role `insights_client` by first retrieving the set value of `tags_file`.

To avoid using an external collection for reading the INI formatted Insights configuration file, I made only use of `ansible.builtin` modules. Parsing INI files is unfortunately a bit cumbersome with `ansible.builtin` when the INI file is on a remote host.

If an external collection is fine to use, please let me know, then I'd use `community.general.from_ini` which would make things easier.

Retrieving the file temporarily using `ansible.builtin.fetch` and then parsing it with the lookup `ansible.builtin.ini` would result in a `changed` state, that's why I dismissed that possibility.

With the added `ansible.builtin.assert` statements I wanted to ensure that:
- That only one configuration option `tags_file` is present
- The `tags_file` value does not contain any equal signs (`=`), which would mess up the `split('=')`

The regular expression used to retrieve the respective option is:

```
^(?<!#)\\s?tags_file\\s?=\\s?.+$
```

I deliberately added a negative lookbehind that ignores lines starting with `#`, so any comment valuesare filtered out by default.

Further, I added optional spacings (`\\s`) to ensure that even values set via any other mechanism (e.g. `community.general.ini_file`) are picked up.

If no `tags_file` option is found, the default is used (`/etc/insights-client/tags.yaml`).

I tried to be as compatible as possible with the existing code style.

The sanity test (`ansible-test sanity --docker`) passed locally, as well as Ansible Lint validated properly against the `production` profile.

Examples are added to both the action plugin, as well as the role.

I prefixed all role variables with `insights_` which is good practice for roles as far as I know and in-line with the latest added argument `insights_proxy`.

Also, it would have been an issue for the Insights option `ansible_host` which is a special variable by Ansible, therefore I would have need to prefix at least this variable with `insights_` (or something similar), so making it more consistent seemed like the best option.

Please let me know if there is anything that needs changing.