### PR TITLE
insights_register: fix insights-client unregistration on force

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ that have any kind of impact on users, such as new & removed features, behaviour
 changes, and bug fixes. Internal changes such as for CI, style/lint, and so on
 are purposely not mentioned here.
 
+## [unreleased]
+### Fixed
+- `insights_register` module: fix the `force_reregister` option to actually
+  unregister
+
 ## [1.2.1]
 ### Fixed
 - `insights_register` module: fix regression that prevented the registration

--- a/plugins/modules/insights_register.py
+++ b/plugins/modules/insights_register.py
@@ -130,7 +130,7 @@ def run_module():
         result['original_message'] = 'Attempting to register ' + insights_name
         if reg_status == 0 and 'unregistered' not in stdout:
             if force_reregister:
-                subprocess.call(register_args, '--unregister')
+                subprocess.call([insights_name, '--unregister'])
             else:
                 result['changed'] = False
                 result['message'] = 'The Insights API has determined that this machine is already registered'


### PR DESCRIPTION
In case `force_reregister` is used, properly invoke `insights-client --unregister` as list command line arguments, so it actually works.