### PR TITLE
doc: improve example of inventory plugin

### DIFF
--- a/.ansible-lint-ignore
+++ b/.ansible-lint-ignore
@@ -1,1 +1,0 @@
-plugins/inventory/insights.py yaml[key-duplicates]  # the examples are flagged

--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -76,11 +76,15 @@ DOCUMENTATION = '''
 '''
 
 EXAMPLES = '''
-# Basic example using environment variables for authentication
+# Set to use this plugin
 plugin: redhat.insights.insights
 
+# Authentication using username and password; either specify these keys,
+# or set the "INSIGHTS_USER" and "INSIGHTS_PASSWORD" environment variables
+user: "insights username"
+password: "insights password"
+
 # Create groups for patching
-plugin: redhat.insights.insights
 get_patches: true
 groups:
   patching: insights_patching.enabled
@@ -90,7 +94,6 @@ groups:
   enhancement_patch: insights_patching.rhea_count > 0
 
 # Filter host by tags and create groups from tags
-plugin: redhat.insights.insights
 get_tags: true
 filter_tags:
   - insights-client/env=prod


### PR DESCRIPTION
Having multiple examples for an inventory plugin in a single "example" block is not seen nicely by ansible-lint: using an inventory plugin means top-level YAML keys, so multiple examples will trigger duplicate YAML keys.

Thus tweak the example to be a single example, with different sections for the various parts; add a small section for the authentication.

The changes make it possible to drop the override for the ansible-lint issue.