### PR TITLE
inventory: fix default of "staleness" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ that have any kind of impact on users, such as new & removed features, behaviour
 changes, and bug fixes. Internal changes such as for CI, style/lint, and so on
 are purposely not mentioned here.
 
+## [unreleased]
+### Changed
+- `inventory` plugin: drop the explicit list of types for the default value
+  of the `staleness` option, so all the types available in Inventory are
+  used as expected (no matter whether new types are available in the future)
+
 ## [1.2.2]
 ### Fixed
 - `insights_register` module: fix the `force_reregister` option to actually

--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -35,8 +35,10 @@ DOCUMENTATION = '''
         default: fqdn
         type: str
       staleness:
-        description: Choose what hosts to return, based on staleness
-        default: [ 'fresh', 'stale', 'unknown' ]
+        description: >
+          Choose what hosts to return, based on staleness; an empty list means
+          "no filtering".
+        default: []
         type: list
         elements: str
       registered_with:


### PR DESCRIPTION
Explicitly setting values means they will be passed in queries to Inventory, filtering the results. The problem is that, in case new types of staleness are added to Inventory, they will not be returned by default, whereas default behaviour is to return the hosts with all the types of staleness.

Since:
- Inventory does not do any filter if no staleness query arguments are passed
- an empty list of values for "staleness" already implies none are passed in the requests to Inventory

then change the default value of the "staleness" option to the empty list.