### PR TITLE
compliance: manually check insights-client status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ are purposely not mentioned here.
 - `inventory` plugin: drop the explicit list of types for the default value
   of the `staleness` option, so all the types available in Inventory are
   used as expected (no matter whether new types are available in the future)
+- `compliance` role: no more rely on the `insights_client` role to ensure
+  systems are registered with Insights, and rather check directly using
+  `insights-client`; this makes it possible to use the role also with other
+  Ansible content for Insights (e.g. the `rhc` system role)
 
 ## [1.2.2]
 ### Fixed

--- a/roles/compliance/README.md
+++ b/roles/compliance/README.md
@@ -5,7 +5,7 @@ Installs, configures, and runs [OpenSCAP](https://www.open-scap.org) compliance 
 
 Requirements
 ------------
-- The Insights client must be installed and configured prior to using the compliance service. See the [insights_client](../insights_client/README.md) role for automated deployment and configuration of the client. 
+- The Insights client must be installed and configured prior to using the compliance service. See the [rhc](https://github.com/linux-system-roles/rhc) role for an automated way to connect to RHSM and Red Hat Insights, or the existing [insights_client](../insights_client/README.md) role for automated deployment and configuration of the client.
 
 - The host must be configured in the [Insights portal](https://console.redhat.com/insights/compliance) prior to running a compliance scan.
 

--- a/roles/compliance/tasks/main.yml
+++ b/roles/compliance/tasks/main.yml
@@ -1,8 +1,20 @@
 ---
-- name: Check for Insights configuration
+- name: Get the insights-client status
+  ansible.builtin.command:
+    argv:
+      - insights-client
+      - --status
+  changed_when: false
+  register: __compliance_insights_status
+  failed_when: __compliance_insights_status.rc not in [0,1]
+
+- name: Check insights-client is registered
   ansible.builtin.assert:
-    that: ansible_local.insights is defined
-    fail_msg: Unable to find insights fact. Have you installed the insights client?
+    that:
+      - >-
+        "This host is registered" in __compliance_insights_status.stdout
+        or "Registered" in __compliance_insights_status.stdout
+    fail_msg: "The system is not registered with insights-client"
 
 - name: Include install tasks
   ansible.builtin.include_tasks: install.yml


### PR DESCRIPTION
Manually check the Insights registration status using `insights-client`, rather than relying on a fact exported by the `insights_client` role. That fact alone does not guarantee that the system is registered, as the `machine-id` file may be on the system even after failed registration attempts.

Bonus point: this makes it possible to use the `compliance` role without the `insights_client` role, as long as something else takes care of registering the system using `insights-client`. Mention the `rhc` role as potential alternative.