### PR TITLE
Use the 'argv' syntax for the 'command' usages

### DIFF
--- a/release.yml
+++ b/release.yml
@@ -35,21 +35,35 @@
 
     - name: Build collection
       ansible.builtin.command:
-        cmd: ansible-galaxy collection build
+        argv:
+          - ansible-galaxy
+          - collection
+          - build
         chdir: "{{ playbook_dir }}"
         creates: "{{ playbook_dir }}/{{ collection_namespace }}-{{ collection_name }}-{{ collection_version }}.tar.gz"
       tags: build
 
     - name: Install collection
       ansible.builtin.command:
-        cmd: "ansible-galaxy collection install {{ collection_namespace }}-{{ collection_name }}-{{ collection_version }}.tar.gz -p ~/.ansible/collections/"
+        argv:
+          - ansible-galaxy
+          - collection
+          - install
+          - "{{ collection_namespace }}-{{ collection_name }}-{{ collection_version }}.tar.gz"
+          - -p
+          - ~/.ansible/collections/
         chdir: "{{ playbook_dir }}"
       changed_when: true
       tags: install
 
     - name: Publish collection
       ansible.builtin.command:
-        cmd: "ansible-galaxy collection publish --api-key={{ api_key }} {{ collection_namespace }}-{{ collection_name }}-{{ collection_version }}.tar.gz"
+        argv:
+          - ansible-galaxy
+          - collection
+          - publish
+          - "--api-key={{ api_key }}"
+          - "{{ collection_namespace }}-{{ collection_name }}-{{ collection_version }}.tar.gz"
         chdir: "{{ playbook_dir }}"
       changed_when: true
       tags: publish
@@ -57,7 +71,10 @@
     - name: Git cleanup
       # noqa: command-instead-of-module the git module does not do 'clean'
       ansible.builtin.command:
-        cmd: git reset --hard
+        argv:
+          - git
+          - reset
+          - --hard
       changed_when: true
       tags: cleanup
 

--- a/roles/compliance/tasks/run.yml
+++ b/roles/compliance/tasks/run.yml
@@ -1,4 +1,7 @@
 ---
 - name: Run compliance scan
-  ansible.builtin.command: insights-client --compliance
+  ansible.builtin.command:
+    argv:
+      - insights-client
+      - --compliance
   changed_when: true

--- a/roles/insights_client/handlers/main.yml
+++ b/roles/insights_client/handlers/main.yml
@@ -1,5 +1,7 @@
 ---
 - name: Run insights-client
-  ansible.builtin.command: insights-client
+  ansible.builtin.command:
+    argv:
+      - insights-client
   changed_when: true
   become: true


### PR DESCRIPTION
Switch all the usages of the `command` modules to the 'argv' syntax for specifying the command to run. While this syntax is more verbose and requires manually splitting a command, in practice has few advantages:
- it keeps command line invocations shorter and easier to read (IMHO), especially long ones
- there is no need to do quoting for arguments, especially in case of arguments with spaces (YAML quoting is still needed though)
- adding/removing parameters is easier, and their changes is easier to spot in diffs

There should be no behaviour change.