### PR TITLE
Document root requirements for insights-client modules

### DIFF
--- a/docs/templates/docs.md.j2
+++ b/docs/templates/docs.md.j2
@@ -22,6 +22,7 @@
 ====================================
 - [Synopsis](Synopsis)
 - [Requirements](Requirements)
+- [Notes](Notes)
 - [Parameters](Parameters)
 - [Examples](Examples)
 
@@ -31,6 +32,13 @@
 ## Requirements
 {% if docs.requirements | d(none) is not none %}
 {{ pretty_md_list(docs.requirements) }}
+{% else %}
+(none)
+{% endif %}
+
+## Notes
+{% if docs.notes | d(none) is not none %}
+{{ pretty_md_list(docs.notes) }}
 {% else %}
 (none)
 {% endif %}

--- a/plugins/modules/insights_config.py
+++ b/plugins/modules/insights_config.py
@@ -13,6 +13,9 @@ short_description: This module handles initial configuration of the insights cli
 description: >
     Supply values for various configuration options that you would like to use.
     On install this module will add those values to the insights-client.conf file prior to registering.
+notes:
+  - It is possible to interact with `insights-client` only as root,
+    so root permissions are required to successfully run this module.
 options:
   username:
     description: >

--- a/plugins/modules/insights_register.py
+++ b/plugins/modules/insights_register.py
@@ -19,6 +19,9 @@ short_description: This module registers the insights client
 description: >
   This module will check the current registration status, unregister if needed,
   and then register the insights client (and update the display_name if needed)
+notes:
+  - It is possible to interact with `insights-client` only as root,
+    so root permissions are required to successfully run this module.
 
 options:
   state:


### PR DESCRIPTION
Running `insights-client` requires root permissions; add a note about it in the documentation of the `insights_config` and `insights_register` modules.

Extend the Markdown template for their documentation to output also the module notes.

The documentation will be regenerated before a new release; nevertheless, the result of this MR can be checked by running
```bash
$ cd docs && ansible-playbook create_docs.yml
```