### PR TITLE
Final changes for long lines

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,7 +1,2 @@
 ---
 extends: default
-rules:
-  line-length:
-    max: 100
-    ignore: |
-      /release.yml

--- a/release.yml
+++ b/release.yml
@@ -11,6 +11,10 @@
     api_key: undef
 
   tasks:
+    - name: Set facts
+      ansible.builtin.set_fact:
+        collection_archive: "{{ collection_namespace }}-{{ collection_name }}-{{ collection_version }}.tar.gz"
+
     - name: Update namespace and name
       block:
         - name: Fix namespace and name references in files
@@ -40,7 +44,7 @@
           - collection
           - build
         chdir: "{{ playbook_dir }}"
-        creates: "{{ playbook_dir }}/{{ collection_namespace }}-{{ collection_name }}-{{ collection_version }}.tar.gz"
+        creates: "{{ playbook_dir }}/{{ collection_archive }}"
       tags: build
 
     - name: Install collection
@@ -49,7 +53,7 @@
           - ansible-galaxy
           - collection
           - install
-          - "{{ collection_namespace }}-{{ collection_name }}-{{ collection_version }}.tar.gz"
+          - "{{ collection_archive }}"
           - -p
           - ~/.ansible/collections/
         chdir: "{{ playbook_dir }}"
@@ -63,7 +67,7 @@
           - collection
           - publish
           - "--api-key={{ api_key }}"
-          - "{{ collection_namespace }}-{{ collection_name }}-{{ collection_version }}.tar.gz"
+          - "{{ collection_archive }}"
         chdir: "{{ playbook_dir }}"
       changed_when: true
       tags: publish

--- a/release.yml
+++ b/release.yml
@@ -4,16 +4,20 @@
   gather_facts: false
   connection: local
   vars:
+    # yamllint disable rule:line-length
     collection_namespace: "{{ namespace  | lower }}"
     collection_name: insights
     collection_version: "{{ github_tag.split('/')[-1] | regex_search('(\\d.\\d.\\d.*)') }}"
     collection_repo: https://github.com/redhatinsights/ansible-collections-insights
     api_key: undef
+    # yamllint enable rule:line-length
 
   tasks:
     - name: Set facts
       ansible.builtin.set_fact:
+        # yamllint disable rule:line-length
         collection_archive: "{{ collection_namespace }}-{{ collection_name }}-{{ collection_version }}.tar.gz"
+        # yamllint enable rule:line-length
 
     - name: Update namespace and name
       block:

--- a/roles/insights_client/tasks/main.yml
+++ b/roles/insights_client/tasks/main.yml
@@ -36,13 +36,13 @@
     state: present
   become: true
 
-- name: Change permissions of Insights Config directory so that Insights System ID can be read
+- name: Change permissions of Insights Config directory so that Insights System ID can be read  # yamllint disable-line rule:line-length
   ansible.builtin.file:
     path: /etc/insights-client
     mode: og=rx
   become: true
 
-- name: Change permissions of machine_id file so that Insights System ID can be read
+- name: Change permissions of machine_id file so that Insights System ID can be read  # yamllint disable-line rule:line-length
   ansible.builtin.file:
     path: /etc/insights-client/machine-id
     mode: og=r


### PR DESCRIPTION
This PR deals with the remaining issues with long lines (i.e. longer than 80 characters), for which there are special bits in the yamllint configuration.

There only code change is the factoring of a filename in the `release.yml` as own fact, so there is less repetition and a shorter way to use it. Other than that, there are additional yamllint exclusions for `line-length` where it makes sense to keep long lines, and the removal of the special yamllint configuration bits.