### PR TITLE
ci/lint fixes; bump ansible to 2.15

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -21,6 +21,15 @@ jobs:
         with:
           path: ansible_collections/redhat/insights
 
+      - name: Workaround ansible-lint action bug
+        run: |
+          # create a symlink to the .git directory of the checkout
+          # in the local directory: the current ansible-lint action (v24.5.0)
+          # does not use its "working_directory" for the .git directory
+          # of the checkout; regression introduced by
+          # https://github.com/ansible/ansible-lint/pull/4103
+          ln -s ansible_collections/redhat/insights/.git .
+
       - name: Set Ansible environment variables (#1)
         run: |
           echo "ANSIBLE_COLLECTIONS_PATH=$PWD" >> "$GITHUB_ENV"

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -26,10 +26,6 @@ jobs:
         exclude:
           - ansible: ''
         include:
-          - ansible: '2.14'
-            python: '3.9'
-          - ansible: '2.14'
-            python: '3.11'
           - ansible: '2.15'
             python: '3.9'
           - ansible: '2.15'

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,2 +1,0 @@
----
-extends: default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ changes, and bug fixes. Internal changes such as for CI, style/lint, and so on
 are purposely not mentioned here.
 
 ## [unreleased]
+### Changed
+- The minimum Ansible Core version supported is now 2.15.
+
 ### Added
 - `inventory` plugin: new authentication method using a Red Hat service account:
   there is a new `authentication` option for choosing the authentication method,

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.14.0"
+requires_ansible: ">=2.15.0"

--- a/roles/compliance/tasks/install.yml
+++ b/roles/compliance/tasks/install.yml
@@ -2,6 +2,7 @@
 - name: Install OpenSCAP packages
   # noqa package-latest it needs to ensure that the latest available packages
   #                     are installed
+  # noqa fqcn[action-core]
   ansible.builtin.yum:
     name:
       - openscap

--- a/roles/insights_client/tasks/main.yml
+++ b/roles/insights_client/tasks/main.yml
@@ -15,6 +15,7 @@
 #     limitations under the License.
 #
 - name: Install 'insights-client'
+  # noqa fqcn[action-core]
   ansible.builtin.yum:
     name: insights-client
   become: true

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,1 +1,0 @@
-plugins/inventory/insights.py validate-modules:missing-gplv3-license # the plugin is licensed as Apache 2.0


### PR DESCRIPTION
- fix the CI `ansible-lint` job adding a workaround for a bug in the `ansible-lint` action
- allow the `yum` module for now, to support RHEL 7
- drop the yamllint configuration file, now empty
- bump the ansible requirement to 2.15, following the 2.14 EOL

See the messages of the individual commits for longer explanations.