### PR TITLE
fix: compliance: require priviledge escalation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ are purposely not mentioned here.
   `insights-client`; this makes it possible to use the role also with other
   Ansible content for Insights (e.g. the `rhc` system role)
 
+### Fixed
+- `compliance` role: no more require priviledge escalation at playbook level
+
 ## [1.2.2]
 ### Fixed
 - `insights_register` module: fix the `force_reregister` option to actually

--- a/roles/compliance/tasks/install.yml
+++ b/roles/compliance/tasks/install.yml
@@ -9,3 +9,4 @@
       - scap-security-guide
       - openscap-scanner
     state: latest
+  become: true

--- a/roles/compliance/tasks/run.yml
+++ b/roles/compliance/tasks/run.yml
@@ -5,3 +5,4 @@
       - insights-client
       - --compliance
   changed_when: true
+  become: true


### PR DESCRIPTION
This fixes the ability to run the role and install without privilege escalation at playbook level.

Obsoletes/replaces PRs #63 and #64, which saw no actions for quite some time.