### PR TITLE
inventory: bump Inventory and Patchman limits per requests

### DIFF
--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -299,7 +299,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         return results
 
     def get_tags(self, ids):
-        first_url = "api/inventory/v1/hosts/%s/tags?per_page=50" % ','.join(ids)
+        first_url = "api/inventory/v1/hosts/%s/tags?per_page=100" % ','.join(ids)
         url = '%s/%s' % (self.server, first_url)
         results = {}
 
@@ -347,7 +347,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         self._read_config_data(path)
 
         self.server = self.get_option('server')
-        url = "%s/api/inventory/v1/hosts?" % (self.server)
+        url = "%s/api/inventory/v1/hosts?per_page=100" % (self.server)
         strict = self.get_option('strict')
         get_patches = self.get_option('get_patches')
         get_system_advisories = self.get_option('get_system_advisories')

--- a/plugins/inventory/insights.py
+++ b/plugins/inventory/insights.py
@@ -277,7 +277,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 result['attributes'][patching_info] = patching_info_result
             return results
 
-        query = "api/patch/v3/systems?filter[stale]=%s" % stale
+        query = "api/patch/v3/systems?limit=100&filter[stale]=%s" % stale
         url = format_url(self.server, query, filter_tags)
         results = []
         while url:


### PR DESCRIPTION
- the default number of hosts per request returned by Inventory is 50, with a current maximum of 100
- the default number of hosts per request returned by Patchman is 20, with a current maximum of 100

Hence bump both the limits to their maximum values, to reduce the number of requests.

There should be no behaviour change, as pagination is already handled.