### PR TITLE
ci: add workaround for another ansible-lint action regression

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -21,6 +21,17 @@ jobs:
         with:
           path: ansible_collections/redhat/insights
 
+      - name: Workaround ansible-lint action bug
+        run: |
+          # create a symlink to the .git directory of the checkout
+          # in the local directory: the current ansible-lint action (v24.6.1)
+          # prepends "working_directory" to the output location for files in
+          # the .git directoryof the checkout; regression introduced by
+          # https://github.com/ansible/ansible-lint/pull/4213
+          mkdir -p ansible_collections/redhat/insights
+          ln -s ../../../.git ansible_collections/redhat/insights/
+        working-directory: ansible_collections/redhat/insights
+
       - name: Set Ansible environment variables (#1)
         run: |
           echo "ANSIBLE_COLLECTIONS_PATH=$PWD" >> "$GITHUB_ENV"

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -21,15 +21,6 @@ jobs:
         with:
           path: ansible_collections/redhat/insights
 
-      - name: Workaround ansible-lint action bug
-        run: |
-          # create a symlink to the .git directory of the checkout
-          # in the local directory: the current ansible-lint action (v24.5.0)
-          # does not use its "working_directory" for the .git directory
-          # of the checkout; regression introduced by
-          # https://github.com/ansible/ansible-lint/pull/4103
-          ln -s ansible_collections/redhat/insights/.git .
-
       - name: Set Ansible environment variables (#1)
         run: |
           echo "ANSIBLE_COLLECTIONS_PATH=$PWD" >> "$GITHUB_ENV"


### PR DESCRIPTION
Due to recent changes in the ansible-lint action [1], the location of the output file download via wget is not correct. Hence, for now add a fake structure to work also with the paths 
calculated by the action.

Also, drop the old workaround, which is not needed anymore.

[1] https://github.com/ansible/ansible-lint/pull/4213