### PR TITLE
feat: deprecate insights-client modules & plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ are purposely not mentioned here.
 ### Fixed
 - `compliance` role: no more require priviledge escalation at playbook level
 
+### Deprecated
+- the `insights_client` role, the `insights_config` module/action, and the
+  `insights_register` module are deprecated, and marked for removal in
+  version 2.0.0; the preferred replacement for them is the `rhc` system role,
+  which provides all the features implemented by the deprecated plugins
+
 ## [1.2.2]
 ### Fixed
 - `insights_register` module: fix the `force_reregister` option to actually

--- a/README.md
+++ b/README.md
@@ -5,9 +5,16 @@ Red Hat Insights Collection
 
   - **Inventory source**:
     - [insights](https://github.com/redhatinsights/ansible-collections-insights/blob/master/docs/inventory.md)
+  - **Roles**:
+    - [compliance](https://github.com/redhatinsights/ansible-collections-insights/blob/master/roles/compliance/README.md)
+
+## Included Deprecated Content:
+
   - **Modules**:
     - [insights_config](https://github.com/redhatinsights/ansible-collections-insights/blob/master/docs/insights_config.md)
     - [insights_register](https://github.com/redhatinsights/ansible-collections-insights/blob/master/docs/insights_register.md)
   - **Roles**:
     - [insights_client](https://github.com/redhatinsights/ansible-collections-insights/blob/master/roles/insights_client/README.md)
-    - [compliance](https://github.com/redhatinsights/ansible-collections-insights/blob/master/roles/compliance/README.md)
+
+Following the Semantic Versioning of the Ansible content, all the deprecated
+content will be removed at the next major version (2.0.0).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,17 @@
 ---
 requires_ansible: ">=2.15.0"
+plugin_routing:
+  action:
+    insights_config:
+      deprecation:
+        removal_version: 2.0.0
+        warning_text: Use the 'rhc' system role instead.
+  modules:
+    insights_config:
+      deprecation:
+        removal_version: 2.0.0
+        warning_text: Use the 'rhc' system role instead.
+    insights_register:
+      deprecation:
+        removal_version: 2.0.0
+        warning_text: Use the 'rhc' system role instead.

--- a/plugins/action/insights_config.py
+++ b/plugins/action/insights_config.py
@@ -2,6 +2,9 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.plugins.action import ActionBase
+from ansible.utils.display import Display
+
+display = Display()
 
 
 class ActionModule(ActionBase):
@@ -9,6 +12,12 @@ class ActionModule(ActionBase):
     def run(self, tmp=None, task_vars=None):
 
         result = super(ActionModule, self).run(tmp, task_vars)
+
+        display.deprecated(
+            msg="The insights_config module is deprecated. ",
+            version="2.0.0",
+            collection_name="redhat.insights"
+        )
 
         insights_name = self._task.args.get('insights_name', 'insights-client')
 

--- a/plugins/modules/insights_config.py
+++ b/plugins/modules/insights_config.py
@@ -51,6 +51,13 @@ options:
       This set an optional proxy for the insights client to connect through if the client
       is behind a firewall or requires a proxy. Default is unspecified (none).
     required: false
+deprecated:
+  removed_in: 2.0.0
+  why: >
+    Its functionalities are now provided in a simpler way by the "rhc" system
+    role.
+  alternative: >
+    The "rhc" system role.
 
 author:
     - Jason Stephens (@Jason-RH)

--- a/plugins/modules/insights_register.py
+++ b/plugins/modules/insights_register.py
@@ -53,6 +53,14 @@ options:
     required: false
     type: bool
 
+deprecated:
+  removed_in: 2.0.0
+  why: >
+    Its functionalities are now provided in a simpler way by the "rhc" system
+    role.
+  alternative: >
+    The "rhc" system role.
+
 author:
     - Jason Stephens (@Jason-RH)
 '''

--- a/release.yml
+++ b/release.yml
@@ -28,10 +28,12 @@
             replace: "{{ collection_namespace }}.{{ collection_name }}"
           loop:
             - docs/inventory.md
+            - plugins/action/insights_config.py
             - plugins/inventory/insights.py
             - roles/compliance/tests/compliance.yml
             - roles/compliance/tests/install-only.yml
             - roles/compliance/tests/run-only.yml
+            - roles/insights_client/tasks/main.yml
             - roles/insights_client/tests/example-insights-client-playbook.yml
             - tests/inventory/insights.yml
 

--- a/roles/insights_client/README.md
+++ b/roles/insights_client/README.md
@@ -3,6 +3,9 @@ insights-client
 
 Installs, configures, and registers a system to the [Red Hat Insights service](http://access.redhat.com/insights).  This role is intended to work on Red Hat Enterprise Linux, though it will generally work on any yum based system that has access to the insights-client RPM or the redhat-access-insights RPM.
 
+**NB:** this role is **deprecated**, and it will be removed in version 2.0.0.
+Use the `rhc` system role instead, which provides equivalent functionalities.
+
 Requirements
 ------------
 

--- a/roles/insights_client/tasks/main.yml
+++ b/roles/insights_client/tasks/main.yml
@@ -14,6 +14,17 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 #
+- name: Deprecation warning
+  ansible.builtin.debug:
+    msg: |
+      [DEPRECATION WARNING]: This role will be removed from redhat.insights in
+      version 2.0.0. Use the 'rhc' system role instead.
+      Deprecation warnings can be disabled by setting deprecation_warnings=False
+      in ansible.cfg.
+  when:
+    - lookup("ansible.builtin.config", "DEPRECATION_WARNINGS")
+  run_once: true
+
 - name: Install 'insights-client'
   # noqa fqcn[action-core]
   ansible.builtin.yum:


### PR DESCRIPTION
Recent versions of the "rhc" Ansible system role, shipped as part of the Linux System Roles collection, provide the same amount of Red Hat Insights features as currently provided by the insights-client bits:
- the `insights_config` action/module
- the `insights_register` module
- the `insights_client` role

Since the "rhc" system role is the preferred solution for registration/connection to Red Hat Insights, formally deprecate all the insights-client bits, slating them for removal in the next major version (2.0.0).

The deprecation messages are emitted for each of the deprecated bit, and they are shown only if the deprecation messages are not explicitly disabled by the user. Since the name of the collection is now present in a couple of files, add them to the list of files in which update the collection name on release.

[1] https://github.com/linux-system-roles/rhc