### PR TITLE
fix(ci): ansible-test: set the collection namespace to "redhat"

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -79,7 +79,7 @@ jobs:
         working-directory: repo
         env:
           JINJA_collection_name: insights
-          JINJA_collection_namespace: ${{ github.repository_owner }}
+          JINJA_collection_namespace: redhat
           JINJA_collection_repo: https://github.com/${{ github.repository }}
           JINJA_collection_version: ${{ steps.git-version.outputs.git_version }}
 


### PR DESCRIPTION
The collection namespace set in the sources is "redhat" already, and it is replaced with the proper one on release (or in general, when running the `release.yml` playbook manually).

If the collection namespace is taken from the GitHub owner of the repository for which the ansible-test workflow runs, then there will be a mismatch between what is set in `galaxy.yml` and what is found in the bits of the collection.

Hence, set the collection namespace to "redhat" when generating `galaxy.yml` to create the right source tree for ansible-test.