### PR TITLE
ci: various ansible-test improvements

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -54,6 +54,12 @@ jobs:
           fetch-depth: 0
           path: ansible_collections/redhat/insights
 
+      - name: Configure git
+        run: |
+          set -euxo pipefail
+          git config --global user.email "workflow@github.com"
+          git config --global user.name "GitHub Workflow"
+
       - name: Check out the branch
         run: |
           # Create a branch for the current HEAD, which happens to be a merge
@@ -84,6 +90,10 @@ jobs:
           set -euxo pipefail
           sudo apt-get --no-install-recommends -y install python3 python3-jinja2
           python3 .github/scripts/jinja2-replace galaxy.yml.j2 galaxy.yml
+          # Create a commit with galaxy.yml, so that ansible-test includes it
+          # in payload archives
+          git add --force galaxy.yml
+          git commit -m "auto: generate galaxy.yml"
         working-directory: ansible_collections/redhat/insights
         env:
           JINJA_collection_name: insights


### PR DESCRIPTION
- make the workflow able to use also ansible tags, not only `stable-` branches
- checkout the sources in the right layout, so there is no need to copy them
- ensure that the generated `galaxy.yml` is used by `ansible-test`