### PR TITLE
ci: disable all permissions for workflows

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -6,6 +6,7 @@ on:  # yamllint disable-line rule:truthy
       - main
       - master
   pull_request:
+permissions: {}
 
 jobs:
   ansibe-lint:

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -7,6 +7,7 @@ on:  # yamllint disable-line rule:truthy
       - main
       - master
   pull_request:
+permissions: {}
 
 jobs:
 

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -6,6 +6,7 @@ on:  # yamllint disable-line rule:truthy
       - main
       - master
   pull_request:
+permissions: {}
 
 jobs:
   codespell:

--- a/.github/workflows/galaxy-release.yml
+++ b/.github/workflows/galaxy-release.yml
@@ -4,6 +4,7 @@ on:  # yamllint disable-line rule:truthy
   release:
     types:
       - published
+permissions: {}
 
 jobs:
   release:

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -6,6 +6,7 @@ on:  # yamllint disable-line rule:truthy
       - main
       - master
   pull_request:
+permissions: {}
 
 jobs:
   yamllint:


### PR DESCRIPTION
The GitHub workflows should not need any permission, not even read ones; hence explicitly disable all of them.